### PR TITLE
instant-apps-header: custom-header-html update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.0-beta.14
+
+### instant-apps-header
+
+- Update custom-header-html to use `div` to avoid double nested `header` tags
+
 ## v1.0.0-beta.13
 
 ### instant-apps-header

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://esri.github.io/instant-apps-components",
   "name": "@esri/instant-apps-components",
-  "version": "1.0.0-beta.13",
+  "version": "1.0.0-beta.14",
   "description": "Reusable ArcGIS Instant Apps web components.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/src/components/instant-apps-header/instant-apps-header.tsx
+++ b/src/components/instant-apps-header/instant-apps-header.tsx
@@ -131,7 +131,7 @@ export class InstantAppsHeader {
     return (
       <Host>
         {this.customHeaderHtml ? (
-          [<style>{this.customHeaderCss}</style>, <header innerHTML={this.customHeaderHtml} />]
+          [<style>{this.customHeaderCss}</style>, <div innerHTML={this.customHeaderHtml} />]
         ) : (
           <header
             class={`${CSS.base}${this.dir === 'rtl' ? ` ${CSS.flipRtl}` : ''}${this.logoImage ? ` ${CSS.logoHeight}${this.logoScale}` : ` ${CSS.standardHeight}`}`}


### PR DESCRIPTION
this change is to avoid double nested `header` tags and to prevent breaking custom headers that already exist on production. 