### PR TITLE
Refresh the shareUrl each time it is generated

### DIFF
--- a/src/components/instant-apps-social-share/instant-apps-social-share.tsx
+++ b/src/components/instant-apps-social-share/instant-apps-social-share.tsx
@@ -680,6 +680,9 @@ export class InstantAppsSocialShare {
 
   // VIEW LOGIC
   async generateShareUrl(): Promise<string> {
+    // Update shareUrl--it may have changes since the component was loaded
+    this.shareUrl = window.location.href;
+
     // If view is not ready
     if (!this.view || !this.view?.ready) {
       return this.shareUrl;


### PR DESCRIPTION
The shareUrl is set to `window.location.href` when the instant-apps-social-share component is created, but as the component is used over time, the href might change. With this PR, the shareUrl is updated whenever `generateShareUrl()` is called.