### PR TITLE
fix(a11y): Honor font size browser setting by using rem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.0-beta.34
+
+### a11y
+
+- Converted use of `px` to `rem` for font-size CSS values to honor font size browser settings. 
+
+## v1.0.0-beta.33
+
+### instant-apps-interactive-legend(beta)
+
+- Bug fixes
+
+## v1.0.0-beta.32
+
+### instant-apps-interactive-legend(beta)
+
+- Bug fixes
+
 ## v1.0.0-beta.31
 
 ### instant-apps-interactive-legend(beta)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://esri.github.io/instant-apps-components",
   "name": "@esri/instant-apps-components",
-  "version": "1.0.0-beta.33",
+  "version": "1.0.0-beta.34",
   "description": "Reusable ArcGIS Instant Apps web components.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/src/components/instant-apps-header/instant-apps-header.scss
+++ b/src/components/instant-apps-header/instant-apps-header.scss
@@ -96,7 +96,7 @@
 
       h1 {
         margin: 0;
-        font-size: 20px;
+        font-size: 1.25rem;
         color: var(--calcite-ui-text-1);
         font-weight: 430;
         white-space: nowrap;
@@ -125,7 +125,7 @@
     height: var(--instant-apps-header-height--logo-scale--s);
     .instant-apps-header__header-content {
       h1 {
-        font-size: 18px;
+        font-size: 1.125rem;
       }
     }
   }
@@ -146,7 +146,7 @@
     height: var(--instant-apps-header-height--logo-scale--l);
     .instant-apps-header__header-content {
       h1 {
-        font-size: 22px;
+        font-size: 1.375rem;
       }
     }
   }

--- a/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend-caption/instant-apps-interactive-legend-caption.scss
+++ b/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend-caption/instant-apps-interactive-legend-caption.scss
@@ -1,6 +1,6 @@
 :host {
   display: block;
-  --instant-apps-interactive-legend-heading-font-size: 20px;
+  --instant-apps-interactive-legend-heading-font-size: 1.25rem;
   --instant-apps-interactive-legend-heading-font-weight: 800;
   --instant-apps-interactive-legend-secondary-color: var(--calcite-ui-text-1);
   --instant-apps-interactive-legend-ui-padding: 15px 10px;

--- a/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend-classic/instant-apps-interactive-legend-classic.scss
+++ b/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend-classic/instant-apps-interactive-legend-classic.scss
@@ -1,13 +1,13 @@
 :host {
   display: block;
 
-  --instant-apps-interactive-legend-heading-font-size: 20px;
+  --instant-apps-interactive-legend-heading-font-size: 1.25rem;
   --instant-apps-interactive-legend-heading-font-weight: 800;
   --instant-apps-interactive-legend-caption-font-weight: 450;
   --instant-apps-interactive-legend-secondary-color: var(--calcite-ui-text-1);
-  --instant-apps-interactive-legend-field-name-font-size: 16px;
-  --instant-apps-interactive-legend-total-feature-count-font-size: 13px;
-  --instant-apps-interactive-legend-info-font-size: 14px;
+  --instant-apps-interactive-legend-field-name-font-size: 1rem;
+  --instant-apps-interactive-legend-total-feature-count-font-size: 0.8125rem;
+  --instant-apps-interactive-legend-info-font-size: 0.875rem;
   --instant-apps-interactive-legend-info-item-background--selected: #c7ebff;
   --instant-apps-interactive-legend-info-item-color--selected: var(--calcite-ui-text-2);
   --instant-apps-interactive-legend-secondary-background-color: var(--calcite-ui-background);

--- a/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend-layer-caption/instant-apps-interactive-legend-layer-caption.scss
+++ b/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend-layer-caption/instant-apps-interactive-legend-layer-caption.scss
@@ -1,13 +1,13 @@
 :host {
   display: block;
 
-  --instant-apps-interactive-legend-heading-font-size: 20px;
+  --instant-apps-interactive-legend-heading-font-size: 1.25rem;
   --instant-apps-interactive-legend-heading-font-weight: 800;
   --instant-apps-interactive-legend-caption-font-weight: 450;
   --instant-apps-interactive-legend-secondary-color: var(--calcite-ui-text-1);
-  --instant-apps-interactive-legend-field-name-font-size: 16px;
-  --instant-apps-interactive-legend-total-feature-count-font-size: 13px;
-  --instant-apps-interactive-legend-info-font-size: 14px;
+  --instant-apps-interactive-legend-field-name-font-size: 1rem;
+  --instant-apps-interactive-legend-total-feature-count-font-size: 0.8125rem;
+  --instant-apps-interactive-legend-info-font-size: 0.875rem;
   --instant-apps-interactive-legend-info-item-background--selected: #c7ebff;
   --instant-apps-interactive-legend-info-item-color--selected: var(--calcite-ui-text-2);
   --instant-apps-interactive-legend-secondary-background-color: var(--calcite-ui-background);

--- a/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend.scss
+++ b/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend.scss
@@ -5,5 +5,9 @@
   .esri-legend {
     height: 100%;
   }
+
+  .esri-legend.esri-component.esri-widget.esri-widget--panel {
+    margin: 0;
+  }
 }
 

--- a/src/components/instant-apps-keyboard-shortcuts/instant-apps-keyboard-shortcuts.scss
+++ b/src/components/instant-apps-keyboard-shortcuts/instant-apps-keyboard-shortcuts.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   font-family: var(--calcite-sans-family);
-  font-size: 14px;
+  font-size: 0.875rem;
   background-color: var(--calcite-ui-background);
   color: var(--calcite-ui-text-1);
   table{

--- a/src/components/instant-apps-popover/instant-apps-popover.scss
+++ b/src/components/instant-apps-popover/instant-apps-popover.scss
@@ -8,7 +8,7 @@
   padding: 0 5% 5% 5%;
   max-width: 35vw;
   font-family: var(--calcite-sans-family);
-  font-size: 14px;
+  font-size: 0.875rem;
     
   .instant-apps-popover__action {
     align-self: flex-start;
@@ -39,7 +39,7 @@
     span {
       margin-bottom: 0;
       font-weight: normal;
-      font-size: 14px;
+      font-size: 0.875rem;
       font-family: var(--calcite-sans-family);
     }
 


### PR DESCRIPTION
Converted use of `px` to `rem` for font-size CSS values to honor font size browser settings.

Other fixes: 
fix(interactive legend): margin css update when it is in a floating panel