### PR TITLE
chore: Update packages and CDN links.

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -8,10 +8,10 @@
   }
 </style>
 
-<script type="module" src="https://unpkg.com/@esri/calcite-components@1.0.7/dist/calcite/calcite.esm.js"></script>
-<link rel="stylesheet" type="text/css" href="https://unpkg.com/@esri/calcite-components@1.0.7/dist/calcite/calcite.css" />
+<script type="module" src="<script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>"></script>
+<link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
 
-<link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/light/main.css" />
-<script src="https://js.arcgis.com/next/init.js"></script>
+<link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
+<script src="https://js.arcgis.com/4.27/"></script>
 
 <script type="module" src="./build/instant-apps-components.esm.js"></script>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.0-beta.88
+
+- Update package versions
+
 ## v1.0.0-beta.87
 
 ### instant-apps-header

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@esri/instant-apps-components",
-  "version": "1.0.0-beta.87",
+  "version": "1.0.0-beta.88",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@esri/instant-apps-components",
-      "version": "1.0.0-beta.87",
+      "version": "1.0.0-beta.88",
       "dependencies": {
         "@a11y/focus-trap": "^1.0.5",
         "@esri/arcgis-html-sanitizer": "^3.0.1",
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.16.5",
-        "@esri/calcite-components": "1.0.7",
+        "@esri/calcite-components": "^1.4.2",
         "@stencil/sass": "^2.0.1",
         "@storybook/addon-a11y": "^6.4.9",
         "@storybook/addon-actions": "^6.4.9",
@@ -2258,19 +2258,34 @@
       }
     },
     "node_modules/@esri/calcite-components": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.7.tgz",
-      "integrity": "sha512-Ucw0Ly+hvWl4RDMEcHAv2amMItgMYzCGfJS5M7gnIu9bEXcY2Areo+o0KaqvvdAcIjChsRY9fy05ke3ypw0tuA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.4.2.tgz",
+      "integrity": "sha512-VV91TVeoOONpZ/P2DcF7yCVscJAy5mzPUU5No71ED0zoL7tDut5HXuW8tYesQ6Afcux55Mr+X9wgwi+LUkI4Ig==",
       "dev": true,
       "dependencies": {
-        "@floating-ui/dom": "1.1.0",
-        "@stencil/core": "2.20.0",
+        "@floating-ui/dom": "1.2.9",
+        "@stencil/core": "2.22.3",
         "@types/color": "3.0.3",
         "color": "4.2.3",
-        "focus-trap": "7.2.0",
+        "composed-offset-position": "0.0.4",
+        "dayjs": "1.11.7",
+        "focus-trap": "7.4.2",
         "form-request-submit-polyfill": "2.0.0",
         "lodash-es": "4.17.21",
         "sortablejs": "1.15.0"
+      }
+    },
+    "node_modules/@esri/calcite-components/node_modules/@stencil/core": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
+      "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng==",
+      "dev": true,
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=12.10.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2280,12 +2295,12 @@
       "dev": true
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.0.tgz",
-      "integrity": "sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.9.tgz",
+      "integrity": "sha512-sosQxsqgxMNkV3C+3UqTS6LxP7isRLwX8WMepp843Rb3/b0Wz8+MdUkxJksByip3C2WwLugLHN1b4ibn//zKwQ==",
       "dev": true,
       "dependencies": {
-        "@floating-ui/core": "^1.0.5"
+        "@floating-ui/core": "^1.2.6"
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
@@ -8409,6 +8424,12 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "node_modules/composed-offset-position": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
+      "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw==",
+      "dev": true
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -9642,6 +9663,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -11615,12 +11642,12 @@
       }
     },
     "node_modules/focus-trap": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.2.0.tgz",
-      "integrity": "sha512-v4wY6HDDYvzkBy4735kW5BUEuw6Yz9ABqMYLuTNbzAFPcBOGiGHwwcNVMvUz4G0kgSYh13wa/7TG3XwTeT4O/A==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.2.tgz",
+      "integrity": "sha512-KMjf+H5uDWPkwSQVqE5r/+vOkP5zBWwVBoWPIZxU3gfg+M8IT+Y8s+vXQqZvHEIXyHPKHrSm6m4G4ceF98OZ8w==",
       "dev": true,
       "dependencies": {
-        "tabbable": "^6.0.1"
+        "tabbable": "^6.1.2"
       }
     },
     "node_modules/for-each": {
@@ -21368,9 +21395,9 @@
       "dev": true
     },
     "node_modules/tabbable": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.1.tgz",
-      "integrity": "sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.2.tgz",
+      "integrity": "sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ==",
       "dev": true
     },
     "node_modules/tapable": {
@@ -25644,19 +25671,29 @@
       }
     },
     "@esri/calcite-components": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.7.tgz",
-      "integrity": "sha512-Ucw0Ly+hvWl4RDMEcHAv2amMItgMYzCGfJS5M7gnIu9bEXcY2Areo+o0KaqvvdAcIjChsRY9fy05ke3ypw0tuA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.4.2.tgz",
+      "integrity": "sha512-VV91TVeoOONpZ/P2DcF7yCVscJAy5mzPUU5No71ED0zoL7tDut5HXuW8tYesQ6Afcux55Mr+X9wgwi+LUkI4Ig==",
       "dev": true,
       "requires": {
-        "@floating-ui/dom": "1.1.0",
-        "@stencil/core": "2.20.0",
+        "@floating-ui/dom": "1.2.9",
+        "@stencil/core": "2.22.3",
         "@types/color": "3.0.3",
         "color": "4.2.3",
-        "focus-trap": "7.2.0",
+        "composed-offset-position": "0.0.4",
+        "dayjs": "1.11.7",
+        "focus-trap": "7.4.2",
         "form-request-submit-polyfill": "2.0.0",
         "lodash-es": "4.17.21",
         "sortablejs": "1.15.0"
+      },
+      "dependencies": {
+        "@stencil/core": {
+          "version": "2.22.3",
+          "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
+          "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng==",
+          "dev": true
+        }
       }
     },
     "@floating-ui/core": {
@@ -25666,12 +25703,12 @@
       "dev": true
     },
     "@floating-ui/dom": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.0.tgz",
-      "integrity": "sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.9.tgz",
+      "integrity": "sha512-sosQxsqgxMNkV3C+3UqTS6LxP7isRLwX8WMepp843Rb3/b0Wz8+MdUkxJksByip3C2WwLugLHN1b4ibn//zKwQ==",
       "dev": true,
       "requires": {
-        "@floating-ui/core": "^1.0.5"
+        "@floating-ui/core": "^1.2.6"
       }
     },
     "@fortawesome/fontawesome-common-types": {
@@ -30326,6 +30363,12 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "composed-offset-position": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
+      "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw==",
+      "dev": true
+    },
     "compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -31281,6 +31324,12 @@
       "version": "2.29.3",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
       "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "dev": true
+    },
+    "dayjs": {
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
       "dev": true
     },
     "debug": {
@@ -32872,12 +32921,12 @@
       }
     },
     "focus-trap": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.2.0.tgz",
-      "integrity": "sha512-v4wY6HDDYvzkBy4735kW5BUEuw6Yz9ABqMYLuTNbzAFPcBOGiGHwwcNVMvUz4G0kgSYh13wa/7TG3XwTeT4O/A==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.2.tgz",
+      "integrity": "sha512-KMjf+H5uDWPkwSQVqE5r/+vOkP5zBWwVBoWPIZxU3gfg+M8IT+Y8s+vXQqZvHEIXyHPKHrSm6m4G4ceF98OZ8w==",
       "dev": true,
       "requires": {
-        "tabbable": "^6.0.1"
+        "tabbable": "^6.1.2"
       }
     },
     "for-each": {
@@ -40410,9 +40459,9 @@
       "dev": true
     },
     "tabbable": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.1.tgz",
-      "integrity": "sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.2.tgz",
+      "integrity": "sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ==",
       "dev": true
     },
     "tapable": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://esri.github.io/instant-apps-components",
   "name": "@esri/instant-apps-components",
-  "version": "1.0.0-beta.87",
+  "version": "1.0.0-beta.88",
   "description": "Reusable ArcGIS Instant Apps web components.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.16.5",
-    "@esri/calcite-components": "1.0.7",
+    "@esri/calcite-components": "^1.4.2",
     "@stencil/sass": "^2.0.1",
     "@storybook/addon-a11y": "^6.4.9",
     "@storybook/addon-actions": "^6.4.9",

--- a/src/index.html
+++ b/src/index.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>ArcGIS Instant Apps Components</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/next/init.js"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.0.7/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.0.7/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.27/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/src/instant-apps-control-panel.html
+++ b/src/instant-apps-control-panel.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Instant Apps Components: Control Panel</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/next/init.js"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.0.7/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.0.7/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.27/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/src/instant-apps-export.html
+++ b/src/instant-apps-export.html
@@ -14,9 +14,9 @@
     <title>ArcGIS Instant Apps Components</title>
 
     <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/dark/main.css" />
-    <script src="https://js.arcgis.com/next/init.js"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.0.7/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.0.7/calcite.css" />
+    <script src="https://js.arcgis.com/4.27/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/src/instant-apps-filter-list.html
+++ b/src/instant-apps-filter-list.html
@@ -14,9 +14,9 @@
     <title>ArcGIS Instant Apps Components</title>
 
     <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/dark/main.css" />
-    <script src="https://js.arcgis.com/next/init.js"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.0.7/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.0.7/calcite.css" />
+    <script src="https://js.arcgis.com/4.27/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/src/instant-apps-header.html
+++ b/src/instant-apps-header.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>ArcGIS Instant Apps Components</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/next/init.js"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.0.7/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.0.7/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.27/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/src/instant-apps-interactive-legend.html
+++ b/src/instant-apps-interactive-legend.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>ArcGIS Instant Apps Components</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/next/init.js"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.0.7/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.0.7/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.27/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/src/instant-apps-keyboard-shortcuts.html
+++ b/src/instant-apps-keyboard-shortcuts.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>ArcGIS Instant Apps Components</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/next/init.js"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.0.7/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.0.7/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.27/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/src/instant-apps-measurement.html
+++ b/src/instant-apps-measurement.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>ArcGIS Instant Apps Components</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/next/init.js"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.0.7/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.0.7/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.27/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/src/instant-apps-popovers.html
+++ b/src/instant-apps-popovers.html
@@ -14,9 +14,9 @@
     <title>ArcGIS Instant Apps Components</title>
 
     <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/dark/main.css" />
-    <script src="https://js.arcgis.com/next/init.js"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.0.7/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.0.7/calcite.css" />
+    <script src="https://js.arcgis.com/4.27/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/src/instant-apps-scoreboard.html
+++ b/src/instant-apps-scoreboard.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Instant Apps Components: Scoreboard</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/next/init.js"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.0.7/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.0.7/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.27/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 
@@ -89,10 +89,6 @@
 
       calcite-button {
         margin-top: 10px;
-      }
-
-      instant-apps-scoreboard {
-        --instant-apps-scoreboard-mobile-position-bottom: 50px;
       }
     </style>
   </head>

--- a/src/instant-apps-social-share.html
+++ b/src/instant-apps-social-share.html
@@ -14,9 +14,9 @@
     <title>ArcGIS Instant Apps Components</title>
 
     <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/dark/main.css" />
-    <script src="https://js.arcgis.com/next/init.js"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.0.7/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.0.7/calcite.css" />
+    <script src="https://js.arcgis.com/4.27/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 


### PR DESCRIPTION
- @esri/calcite-components to 1.4.2
- Removed usage of `next` in arcgis js api CDN links
- Removed usage of `unpkg` in CDN links
