### PR TITLE
fix(interactive legend): Single symbol collapsed/Zoom UI issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.0-beta.94
+
+### instant-apps-interactive-legend
+
+- Fix: Always show single symbol when legend element is collapsed and 'Zoom to' is disabled.
+
 ## v1.0.0-beta.93
 
 ### instant-apps-filter-list

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@esri/instant-apps-components",
-  "version": "1.0.0-beta.92",
+  "version": "1.0.0-beta.94",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@esri/instant-apps-components",
-      "version": "1.0.0-beta.92",
+      "version": "1.0.0-beta.94",
       "dependencies": {
         "@a11y/focus-trap": "^1.0.5",
         "@esri/arcgis-html-sanitizer": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://esri.github.io/instant-apps-components",
   "name": "@esri/instant-apps-components",
-  "version": "1.0.0-beta.93",
+  "version": "1.0.0-beta.94",
   "description": "Reusable ArcGIS Instant Apps web components.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend-legend-element/instant-apps-interactive-legend-legend-element.tsx
+++ b/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend-legend-element/instant-apps-interactive-legend-legend-element.tsx
@@ -69,7 +69,7 @@ export class InstantAppsInteractiveLegendLegendElement {
     const nonInteractiveClass = !this.isInteractive ? ` ${CSS.nonInteractive}` : '';
     const nestedUniqueSymbolClass = checkNestedUniqueSymbolLegendElement(this.activeLayerInfo) ? ` ${CSS.nestedUniqueSymbol}` : '';
 
-    let expanded = this.expanded;
+    let expanded = singleSymbol && !this.expanded && !this.zoomTo ? true : this.expanded;
 
     if (this.isRelationshipRamp) {
       const relationshipRampExpandStates = store.get('relationshipRampExpandStates');


### PR DESCRIPTION
Always show single symbol when legend element is collapsed and 'Zoom to' is disabled