### PR TITLE
fix: Update header css to ensure end actions display on mobile

### DIFF
--- a/packages/instant-apps-components/src/components/instant-apps-header/instant-apps-header.scss
+++ b/packages/instant-apps-components/src/components/instant-apps-header/instant-apps-header.scss
@@ -86,6 +86,7 @@
       display: flex;
       align-items: center;
       width: 100%;
+      min-width:0;
 
       a {
         display: flex;


### PR DESCRIPTION
#141

In the current header example if you view in mobile the content in the action end slot (Share button) is not displayed. This PR is to address that issue