### PR TITLE
loadModules and social share updates

### DIFF
--- a/packages/instant-apps-components/.storybook/preview-head.html
+++ b/packages/instant-apps-components/.storybook/preview-head.html
@@ -11,7 +11,7 @@
 <script type="module" src="<script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>"></script>
 <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
 
-<link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
+<link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/light/main.css" />
 <script src="https://js.arcgis.com/4.27/"></script>
 
 <script type="module" src="./build/instant-apps-components.esm.js"></script>

--- a/packages/instant-apps-components/CHANGELOG.md
+++ b/packages/instant-apps-components/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.0-beta.146
+
+### General
+
+- Use 'loadModules' from src/utils/loadModules
+
+### instant-apps-social-share
+
+- Update projection.loadModules to projection.load
+
 ## v1.0.0-beta.145
 
 ### instant-apps-switcher

--- a/packages/instant-apps-components/CHANGELOG.md
+++ b/packages/instant-apps-components/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### instant-apps-social-share
 
 - Update projection.loadModules to projection.load
+- fix: projection point logic
 
 ## v1.0.0-beta.145
 

--- a/packages/instant-apps-components/package-lock.json
+++ b/packages/instant-apps-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@esri/instant-apps-components",
-  "version": "1.0.0-beta.145",
+  "version": "1.0.0-beta.146",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@esri/instant-apps-components",
-      "version": "1.0.0-beta.145",
+      "version": "1.0.0-beta.146",
       "dependencies": {
         "@a11y/focus-trap": "^1.0.5",
         "@ckeditor/ckeditor5-build-classic": "^39.0.1",

--- a/packages/instant-apps-components/package.json
+++ b/packages/instant-apps-components/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://esri.github.io/instant-apps-components",
   "name": "@esri/instant-apps-components",
-  "version": "1.0.0-beta.145",
+  "version": "1.0.0-beta.146",
   "description": "Reusable ArcGIS Instant Apps web components.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/instant-apps-components/src/components/instant-apps-control-panel/instant-apps-control-panel.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-control-panel/instant-apps-control-panel.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, Host, Prop, h } from '@stencil/core';
 import { HostElement } from '@stencil/core/internal';
-import { loadModules } from 'esri-loader';
+import { loadModules } from '../../utils/loadModules';
 import { ControlPanelComponent } from '../../interfaces/interfaces';
 
 const MODE = 'floating';

--- a/packages/instant-apps-components/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend-classic/instant-apps-interactive-legend-classic.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend-classic/instant-apps-interactive-legend-classic.tsx
@@ -26,7 +26,7 @@ import {
   handleFilterChange,
 } from '../support/helpers';
 
-import { loadModules } from 'esri-loader';
+import { loadModules } from '../../../utils/loadModules';
 
 import { FilterMode, IIntLegendLayerData } from './interfaces/interfaces';
 import {
@@ -167,7 +167,7 @@ export class InstantAppsInteractiveLegendClassic {
           await this.reactiveUtils.whenOnce(() => this.legendvm?.view?.updating === false);
           // Initial data setup
           const data = await generateData(this.legendvm, this.reactiveUtils);
-          store.set('data', { ...interactiveLegendState.data, ...data  });
+          store.set('data', { ...interactiveLegendState.data, ...data });
           this.isLoading = false;
           this.setupWatchersAndListeners();
         } catch {
@@ -766,7 +766,7 @@ export class InstantAppsInteractiveLegendClassic {
                   () => !this.legendvm?.view?.updating,
                   async () => {
                     const data = await handleFeatureCount(this.legendvm, interactiveLegendState.data);
-                    store.set("data", {...interactiveLegendState.data, ...data});
+                    store.set('data', { ...interactiveLegendState.data, ...data });
                     this.calculatingFeatureCount = false;
                   },
                   { once: true, initial: true },
@@ -786,7 +786,7 @@ export class InstantAppsInteractiveLegendClassic {
         'change',
         async activeLayerInfo => {
           const data = await generateData(this.legendvm, this.reactiveUtils);
-          store.set('data', { ...interactiveLegendState.data, ...data  });
+          store.set('data', { ...interactiveLegendState.data, ...data });
           forceUpdate(this.el);
           this.handles?.add(
             this.reactiveUtils.on(
@@ -794,7 +794,7 @@ export class InstantAppsInteractiveLegendClassic {
               'change',
               async () => {
                 const data = await generateData(this.legendvm, this.reactiveUtils);
-                store.set('data', { ...interactiveLegendState.data, ...data  });
+                store.set('data', { ...interactiveLegendState.data, ...data });
                 forceUpdate(this.el);
               },
             ),
@@ -813,7 +813,7 @@ export class InstantAppsInteractiveLegendClassic {
       updateStore({ intLegendLayerData: dataForLayer, layerId: fLayer?.id });
       if (this.featureCount) {
         const data = await handleFeatureCount(this.legendvm, interactiveLegendState.data);
-        store.set("data", {...interactiveLegendState.data, ...data});
+        store.set('data', { ...interactiveLegendState.data, ...data });
       }
     }
   }

--- a/packages/instant-apps-components/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend-count/instant-apps-interactive-legend-count.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend-count/instant-apps-interactive-legend-count.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, forceUpdate, h, Prop } from '@stencil/core';
 import { ICategory } from '../instant-apps-interactive-legend-classic/interfaces/interfaces';
-import { loadModules } from 'esri-loader';
+import { loadModules } from '../../../utils/loadModules';
 import { interactiveLegendState } from '../support/store';
 import {
   calculateTotalCount,

--- a/packages/instant-apps-components/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend-relationship/instant-apps-interactive-legend-relationship.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-interactive-legend/instant-apps-interactive-legend-relationship/instant-apps-interactive-legend-relationship.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Prop, Listen } from '@stencil/core';
-import { loadModules } from 'esri-loader';
+import { loadModules } from '../../../utils/loadModules';
 import { FilterMode } from '../instant-apps-interactive-legend-classic/interfaces/interfaces';
 import { getMergedEffect } from '../support/effects';
 import { interactiveLegendState } from '../support/store';

--- a/packages/instant-apps-components/src/components/instant-apps-interactive-legend/support/effects.ts
+++ b/packages/instant-apps-components/src/components/instant-apps-interactive-legend/support/effects.ts
@@ -1,4 +1,4 @@
-import { loadModules } from 'esri-loader';
+import { loadModules } from '../../../utils/loadModules';
 
 interface FeatureLayerFeatureEffect extends __esri.FeatureLayer {
   featureEffect: __esri.FeatureEffect;

--- a/packages/instant-apps-components/src/components/instant-apps-interactive-legend/support/helpers.ts
+++ b/packages/instant-apps-components/src/components/instant-apps-interactive-legend/support/helpers.ts
@@ -1,4 +1,4 @@
-import { loadModules } from 'esri-loader';
+import { loadModules } from '../../../utils/loadModules';
 import { IInteractiveLegendData, ICategories, IIntLegendLayerData, ICategory, FilterMode } from '../instant-apps-interactive-legend-classic/interfaces/interfaces';
 import { getMergedEffect } from './effects';
 import { interactiveLegendState, store } from '../support/store';

--- a/packages/instant-apps-components/src/components/instant-apps-interactive-legend/support/univariateUtils.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-interactive-legend/support/univariateUtils.tsx
@@ -2,7 +2,7 @@ import { pt2px } from './screenUtils';
 import type { Projector } from 'maquette';
 import { createProjector } from 'maquette';
 import { h } from '@stencil/core';
-import { loadModules } from 'esri-loader';
+import { loadModules } from '../../../utils/loadModules';
 import { ColorRampElement, SizeRampElement, UnivariateColorSizeRampElement } from '../../../interfaces/interfaces';
 
 const projector: Projector = createProjector();

--- a/packages/instant-apps-components/src/components/instant-apps-language-switcher/instant-apps-language-switcher.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-language-switcher/instant-apps-language-switcher.tsx
@@ -3,7 +3,7 @@ import { Component, Event, EventEmitter, Method, Prop, State, h } from '@stencil
 import LanguageTranslator_t9n from '../../assets/t9n/instant-apps-language-translator/resources.json';
 import { getMessages } from '../instant-apps-language-translator/support/utils';
 import { Element } from '@stencil/core';
-import { loadModules } from 'esri-loader';
+import { loadModules } from '../../utils/loadModules';
 import { getDefaultLanguage } from '../../utils/locale';
 import { getPortalItemResource, fetchResourceData } from '../../utils/languageSwitcher';
 

--- a/packages/instant-apps-components/src/components/instant-apps-language-translator/instant-apps-language-translator.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-language-translator/instant-apps-language-translator.tsx
@@ -9,7 +9,7 @@ import { EIcons } from './support/enum';
 import { AppSettings, LocaleItem, LocaleSettingItem, LocaleUIData, SettingType } from './support/interfaces';
 
 import LanguageTranslator_t9n from '../../assets/t9n/instant-apps-language-translator/resources.json';
-import { loadModules } from 'esri-loader';
+import { loadModules } from '../../utils/loadModules';
 import { getComponentClosestLanguage } from '../../utils/locale';
 import { getPortalItemResource, fetchResourceData } from '../../utils/languageSwitcher';
 

--- a/packages/instant-apps-components/src/components/instant-apps-scoreboard/instant-apps-scoreboard.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-scoreboard/instant-apps-scoreboard.tsx
@@ -2,7 +2,7 @@
 import { Component, Host, h, Prop, State, Element, Watch, Event, EventEmitter } from '@stencil/core';
 
 // esri-loader
-import { loadModules } from 'esri-loader';
+import { loadModules } from '../../utils/loadModules';
 
 // Utils
 import { getLocaleComponentStrings } from '../../utils/locale';
@@ -104,7 +104,7 @@ export class InstantAppsScoreboard {
    * Optional geometry in which the statistics will be calculated. To re-calculate the scoreboard's statistics based on the current view extent, set this property to `null`.
    */
   @Prop({
-    mutable: true
+    mutable: true,
   })
   geometry: __esri.Geometry | null = null;
 

--- a/packages/instant-apps-components/src/components/instant-apps-social-share/instant-apps-social-share.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-social-share/instant-apps-social-share.tsx
@@ -738,7 +738,7 @@ export class InstantAppsSocialShare {
     const outputSpatialReference = new SpatialReference({
       wkid: 4326,
     });
-    await projection.loadProjection();
+    await projection.load();
     const projectedPoint = projection.project(point, outputSpatialReference) as __esri.Point;
     return projectedPoint;
   }

--- a/packages/instant-apps-components/src/index.html
+++ b/packages/instant-apps-components/src/index.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>ArcGIS Instant Apps Components</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/4.27/"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.28/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/packages/instant-apps-components/src/instant-apps-control-panel.html
+++ b/packages/instant-apps-components/src/instant-apps-control-panel.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Instant Apps Components: Control Panel</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/4.27/"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.28/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/packages/instant-apps-components/src/instant-apps-export.html
+++ b/packages/instant-apps-components/src/instant-apps-export.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>ArcGIS Instant Apps Components</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/4.27/"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.28/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/packages/instant-apps-components/src/instant-apps-filter-list.html
+++ b/packages/instant-apps-components/src/instant-apps-filter-list.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>ArcGIS Instant Apps Components</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/dark/main.css" />
-    <script src="https://js.arcgis.com/4.27/"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/dark/main.css" />
+    <script src="https://js.arcgis.com/4.28/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/packages/instant-apps-components/src/instant-apps-header.html
+++ b/packages/instant-apps-components/src/instant-apps-header.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>ArcGIS Instant Apps Components</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/4.27/"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.28/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/packages/instant-apps-components/src/instant-apps-interactive-legend.html
+++ b/packages/instant-apps-components/src/instant-apps-interactive-legend.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>ArcGIS Instant Apps Components</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/4.27/"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.28/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/packages/instant-apps-components/src/instant-apps-keyboard-shortcuts.html
+++ b/packages/instant-apps-components/src/instant-apps-keyboard-shortcuts.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>ArcGIS Instant Apps Components</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/4.27/"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.28/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/packages/instant-apps-components/src/instant-apps-landing-page.html
+++ b/packages/instant-apps-components/src/instant-apps-landing-page.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ArcGIS Instant Apps: Landing Page</title>
-    <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/4.27/"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.28/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
     <style>

--- a/packages/instant-apps-components/src/instant-apps-language-translator.html
+++ b/packages/instant-apps-components/src/instant-apps-language-translator.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>ArcGIS Instant Apps Components: Language Translator/Switcher</title>
     <script src="/ckeditor5/ckeditor5-build-classic/build/ckeditor.js"></script>
-    <link rel="stylesheet" href="https://js.arcgis.com/4.27/@arcgis/core/assets/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/4.27/"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.5.0/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.5.0/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.28/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
     <style>

--- a/packages/instant-apps-components/src/instant-apps-measurement.html
+++ b/packages/instant-apps-components/src/instant-apps-measurement.html
@@ -8,81 +8,77 @@
 
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>ArcGIS Instant Apps Components</title>
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
-  <title>ArcGIS Instant Apps Components</title>
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.28/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
+    <script type="module" src="/build/instant-apps-components.esm.js"></script>
+    <script nomodule src="/build/instant-apps-components.js"></script>
 
-  <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
-  <script src="https://js.arcgis.com/4.27/"></script>
-  <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
-  <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
-  <script type="module" src="/build/instant-apps-components.esm.js"></script>
-  <script nomodule src="/build/instant-apps-components.js"></script>
+    <style>
+      html,
+      body,
+      #viewDiv {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
 
-  <style>
-    html,
-    body,
-    #viewDiv {
-      width: 100%;
-      height: 100%;
-      margin: 0;
-      padding: 0;
-    }
-  </style>
-</head>
+  <body>
+    <div id="viewDiv"></div>
 
-<body>
-  <div id="viewDiv"></div>
+    <script>
+      require(['esri/WebMap', 'esri/widgets/Expand', 'esri/views/MapView', 'esri/core/reactiveUtils', 'esri/config'], (WebMap, Expand, MapView, reactiveUtils, esriConfig) => {
+        esriConfig.portalUrl = 'https://nw-brews.mapsdevext.arcgis.com';
 
-  <script>
-    require(['esri/WebMap', 'esri/widgets/Expand', 'esri/views/MapView', 'esri/core/reactiveUtils', 'esri/config'], (WebMap, Expand, MapView, reactiveUtils, esriConfig) => {
-      esriConfig.portalUrl = 'https://nw-brews.mapsdevext.arcgis.com';
+        const map = new WebMap({
+          portalItem: {
+            id: '8891ee1d2e0e428bb96c58b8ecf8c408',
+          },
+        });
 
-      const map = new WebMap({
-        portalItem: {
-          id: '8891ee1d2e0e428bb96c58b8ecf8c408',
-        },
+        const url = new URL(window.location.href);
+        const searchParams = url.searchParams;
+        let center = searchParams.get('center');
+        let zoom = searchParams.get('level');
+        if (center) center = center.split(';').map(item => parseFloat(item));
+        if (zoom) zoom = parseInt(zoom);
+
+        const view = new MapView({
+          map,
+          container: 'viewDiv',
+          zoom,
+          center,
+        });
+
+        const measure = document.createElement('instant-apps-measurement');
+        measure.view = view;
+        measure.areaUnit = 'hectares';
+        measure.linearUnit = 'nautical-miles';
+        // Optionally specify an active tool
+        measure.activeToolType = 'point';
+        // disable popups when measure tools are active
+        measure.addEventListener('measureActive', e => {
+          view.popup.autoOpenEnabled = !e?.detail;
+        });
+        const measureExpand = new Expand({
+          view,
+          mode: 'floating',
+          expandIcon: 'measure',
+          group: 'top-right',
+          content: measure,
+          expanded: true,
+        });
+        view.ui.add(measureExpand, 'top-right');
       });
-
-      const url = new URL(window.location.href);
-      const searchParams = url.searchParams;
-      let center = searchParams.get('center');
-      let zoom = searchParams.get('level');
-      if (center) center = center.split(';').map(item => parseFloat(item));
-      if (zoom) zoom = parseInt(zoom);
-
-      const view = new MapView({
-        map,
-        container: 'viewDiv',
-        zoom,
-        center,
-      });
-
-      const measure = document.createElement('instant-apps-measurement');
-      measure.view = view;
-      measure.areaUnit = 'hectares';
-      measure.linearUnit = 'nautical-miles';
-      // Optionally specify an active tool
-      measure.activeToolType = "point";
-      // disable popups when measure tools are active
-      measure.addEventListener('measureActive', e => {
-        view.popup.autoOpenEnabled = !e?.detail;
-      });
-      const measureExpand = new Expand({
-        view,
-        mode: 'floating',
-        expandIcon: 'measure',
-        group: 'top-right',
-        content: measure,
-        expanded: true,
-      });
-      view.ui.add(measureExpand, 'top-right');
-
-
-    });
-  </script>
-</body>
-
+    </script>
+  </body>
 </html>

--- a/packages/instant-apps-components/src/instant-apps-popovers.html
+++ b/packages/instant-apps-components/src/instant-apps-popovers.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>ArcGIS Instant Apps Components</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/dark/main.css" />
-    <script src="https://js.arcgis.com/4.27/"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/dark/main.css" />
+    <script src="https://js.arcgis.com/4.28/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/packages/instant-apps-components/src/instant-apps-scoreboard-2.html
+++ b/packages/instant-apps-components/src/instant-apps-scoreboard-2.html
@@ -8,172 +8,174 @@
 
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Instant Apps Components: Scoreboard</title>
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
-  <title>Instant Apps Components: Scoreboard</title>
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.28/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
+    <script type="module" src="/build/instant-apps-components.esm.js"></script>
+    <script nomodule src="/build/instant-apps-components.js"></script>
 
-  <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
-  <script src="https://js.arcgis.com/4.27/"></script>
-  <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
-  <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
-  <script type="module" src="/build/instant-apps-components.esm.js"></script>
-  <script nomodule src="/build/instant-apps-components.js"></script>
+    <style>
+      html,
+      body {
+        box-sizing: border-box;
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+      }
 
-  <style>
-    html,
-    body {
-      box-sizing: border-box;
-      width: 100%;
-      height: 100%;
-      margin: 0;
-      padding: 0;
-    }
+      body {
+        display: flex;
+        flex-direction: column;
+      }
 
-    body {
-      display: flex;
-      flex-direction: column;
-    }
+      #appContainer {
+        display: flex;
+        width: 100%;
+        flex-grow: 1;
+      }
 
-    #appContainer {
-      display: flex;
-      width: 100%;
-      flex-grow: 1;
-    }
+      #viewDiv,
+      #scoreboardContainer {
+        width: 50%;
+      }
 
-    #viewDiv,
-    #scoreboardContainer {
-      width: 50%;
-    }
+      #scoreboardContainer {
+        display: flex;
+      }
 
-    #scoreboardContainer {
-      display: flex;
-    }
+      #scoreboardContainer div {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+      }
+    </style>
+  </head>
 
-    #scoreboardContainer div {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      width: 100%;
-    }
-  </style>
-</head>
-
-<body>
-  <instant-apps-header id="instant-apps-header" slot="header" title-text="Instant Apps: Scoreboard" text-color="#fff"
-    background-color="#151515"
-    logo-image="https://www.esri.com/content/dam/esrisites/en-us/common/icons/product-logos/arcgis-instant-apps-64.svg"
-    logo-image-alt-text="ArcGIS Instant Apps logo"
-    logo-link="https://www.esri.com/en-us/arcgis/products/arcgis-instant-apps/overview" info-button="true"
-    info-title-text="Open information" info-is-open="true">
-    <instant-apps-social-share slot="actions-end" share-button-color="neutral"
-      popover-button-icon-scale="s"></instant-apps-social-share>
-  </instant-apps-header>
-  <div id="appContainer">
-    <div id="scoreboardContainer">
-      <instant-apps-scoreboard position="left" mode="pinned" auto-dock-enabled="false"></instant-apps-scoreboard>
-      <div>Content</div>
+  <body>
+    <instant-apps-header
+      id="instant-apps-header"
+      slot="header"
+      title-text="Instant Apps: Scoreboard"
+      text-color="#fff"
+      background-color="#151515"
+      logo-image="https://www.esri.com/content/dam/esrisites/en-us/common/icons/product-logos/arcgis-instant-apps-64.svg"
+      logo-image-alt-text="ArcGIS Instant Apps logo"
+      logo-link="https://www.esri.com/en-us/arcgis/products/arcgis-instant-apps/overview"
+      info-button="true"
+      info-title-text="Open information"
+      info-is-open="true"
+    >
+      <instant-apps-social-share slot="actions-end" share-button-color="neutral" popover-button-icon-scale="s"></instant-apps-social-share>
+    </instant-apps-header>
+    <div id="appContainer">
+      <div id="scoreboardContainer">
+        <instant-apps-scoreboard position="left" mode="pinned" auto-dock-enabled="false"></instant-apps-scoreboard>
+        <div>Content</div>
+      </div>
+      <div id="viewDiv"></div>
     </div>
-    <div id="viewDiv"></div>
-  </div>
 
-  <script>
-    require(['esri/WebMap', 'esri/views/MapView', 'esri/core/reactiveUtils', 'esri/config', 'esri/core/Collection', 'esri/widgets/Sketch', 'esri/layers/GraphicsLayer'], (
-      WebMap,
-      MapView,
-      reactiveUtils,
-      esriConfig,
-      Collection,
-      Sketch,
-      GraphicsLayer,
-    ) => {
-      // // Init dummy data
-      let items = [
-        {
-          layer: {
-            id: 'PowerPlants_WorldResourcesInstitute_5563',
-            url: 'https://services1.arcgis.com/4yjifSiIG17X0gW4/arcgis/rest/services/PowerPlants_WorldResourcesInstitute/FeatureServer',
+    <script>
+      require(['esri/WebMap', 'esri/views/MapView', 'esri/core/reactiveUtils', 'esri/config', 'esri/core/Collection', 'esri/widgets/Sketch', 'esri/layers/GraphicsLayer'], (
+        WebMap,
+        MapView,
+        reactiveUtils,
+        esriConfig,
+        Collection,
+        Sketch,
+        GraphicsLayer,
+      ) => {
+        // // Init dummy data
+        let items = [
+          {
+            layer: {
+              id: 'PowerPlants_WorldResourcesInstitute_5563',
+              url: 'https://services1.arcgis.com/4yjifSiIG17X0gW4/arcgis/rest/services/PowerPlants_WorldResourcesInstitute/FeatureServer',
+            },
+            field: 'capacity_mw',
+            label: 'Capacity (MW)',
+            operation: 'avg',
+            visible: true,
           },
-          field: 'capacity_mw',
-          label: 'Capacity (MW)',
-          operation: 'avg',
-          visible: true,
-        },
-        {
-          layer: {
-            id: 'PowerPlants_WorldResourcesInstitute_5563',
-            url: 'https://services1.arcgis.com/4yjifSiIG17X0gW4/arcgis/rest/services/PowerPlants_WorldResourcesInstitute/FeatureServer',
+          {
+            layer: {
+              id: 'PowerPlants_WorldResourcesInstitute_5563',
+              url: 'https://services1.arcgis.com/4yjifSiIG17X0gW4/arcgis/rest/services/PowerPlants_WorldResourcesInstitute/FeatureServer',
+            },
+            field: 'year_of_capacity_data',
+            label: 'Year of Capacity Data avg',
+            operation: 'avg',
+            visible: true,
           },
-          field: 'year_of_capacity_data',
-          label: 'Year of Capacity Data avg',
-          operation: 'avg',
-          visible: true,
-        },
-      ];
+        ];
 
-      // Set up web scene/view
-      esriConfig.portalUrl = 'https://holistic.mapsdevext.arcgis.com';
-      const gLayer = new GraphicsLayer();
+        // Set up web scene/view
+        esriConfig.portalUrl = 'https://holistic.mapsdevext.arcgis.com';
+        const gLayer = new GraphicsLayer();
 
-      const map = new WebMap({
-        portalItem: {
-          id: '7e252d7ebdc448378e7d1c3ff15c5703',
-        },
-        layers: [gLayer]
-      });
-
-      const view = new MapView({
-        map: map,
-        container: 'viewDiv',
-      });
-
-      const scoreboard = document.querySelector('instant-apps-scoreboard');
-      scoreboard.view = view;
-      scoreboard.items = items;
-
-
-
-      const sketch = new Sketch({
-        view,
-        layer: gLayer,
-        creationMode: "update",
-
-        visibleElements: {
-          createTools: {
-            point: false,
-            circle: false,
-            polyline: false
+        const map = new WebMap({
+          portalItem: {
+            id: '7e252d7ebdc448378e7d1c3ff15c5703',
           },
-          selectionTools: {
-            "lasso-selection": false
+          layers: [gLayer],
+        });
+
+        const view = new MapView({
+          map: map,
+          container: 'viewDiv',
+        });
+
+        const scoreboard = document.querySelector('instant-apps-scoreboard');
+        scoreboard.view = view;
+        scoreboard.items = items;
+
+        const sketch = new Sketch({
+          view,
+          layer: gLayer,
+          creationMode: 'update',
+
+          visibleElements: {
+            createTools: {
+              point: false,
+              circle: false,
+              polyline: false,
+            },
+            selectionTools: {
+              'lasso-selection': false,
+            },
+            undoRedoMenu: false,
+            settingsMenu: false,
           },
-          undoRedoMenu: false,
-          settingsMenu: false
-        }
-      });
-      view.ui.add(sketch, 'top-right');
+        });
+        view.ui.add(sketch, 'top-right');
 
-      sketch.on('create', e => {
-        if (e.state === 'complete') {
-          scoreboard.geometry = e.graphic.geometry;
-        }
-      });
+        sketch.on('create', e => {
+          if (e.state === 'complete') {
+            scoreboard.geometry = e.graphic.geometry;
+          }
+        });
 
-      sketch.on('update', e => {
-        const eInfoType = e.toolEventInfo?.type;
-        const types = ["move-stop", "scale-stop", "rotate-stop"];
-        const complete = types.indexOf(eInfoType) > -1;
-        if (complete) {
-          scoreboard.geometry = e.graphics[0].geometry;
-        }
-      });
+        sketch.on('update', e => {
+          const eInfoType = e.toolEventInfo?.type;
+          const types = ['move-stop', 'scale-stop', 'rotate-stop'];
+          const complete = types.indexOf(eInfoType) > -1;
+          if (complete) {
+            scoreboard.geometry = e.graphics[0].geometry;
+          }
+        });
 
-      sketch.on('delete', e => {
-        scoreboard.geometry = null;
+        sketch.on('delete', e => {
+          scoreboard.geometry = null;
+        });
       });
-    });
-  </script>
-</body>
-
+    </script>
+  </body>
 </html>

--- a/packages/instant-apps-components/src/instant-apps-scoreboard.html
+++ b/packages/instant-apps-components/src/instant-apps-scoreboard.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Instant Apps Components: Scoreboard</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/4.27/"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.28/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/packages/instant-apps-components/src/instant-apps-social-share.html
+++ b/packages/instant-apps-components/src/instant-apps-social-share.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>ArcGIS Instant Apps Components</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/next/esri/themes/dark/main.css" />
-    <script src="https://js.arcgis.com/4.27/"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/dark/main.css" />
+    <script src="https://js.arcgis.com/4.28/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/packages/instant-apps-components/src/instant-apps-splash.html
+++ b/packages/instant-apps-components/src/instant-apps-splash.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>ArcGIS Instant Apps Components</title>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/4.27/"></script>
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.4.2/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.4.2/calcite.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.28/"></script>
+    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 

--- a/packages/instant-apps-components/src/utils/languageSwitcher.ts
+++ b/packages/instant-apps-components/src/utils/languageSwitcher.ts
@@ -1,20 +1,18 @@
-import { loadModules } from "esri-loader";
-
+import { loadModules } from '../utils/loadModules';
 
 export async function fetchResourceData(request, resource: __esri.PortalItemResource): Promise<any> {
   try {
-    const token = resource?.portalItem?.portal?.["credential"]?.["token"];
-    const reqConfig: __esri.RequestOptions = { responseType: 'json'} ;
+    const token = resource?.portalItem?.portal?.['credential']?.['token'];
+    const reqConfig: __esri.RequestOptions = { responseType: 'json' };
     if (token) reqConfig.query = { token };
-    var cacheBuster = "cacheBuster=" + Date.now();
+    var cacheBuster = 'cacheBuster=' + Date.now();
     const url = `${resource.url}?${cacheBuster}`;
     const reqRes = await request(url, reqConfig);
     const t9nData = reqRes.data;
     return Promise.resolve(t9nData);
-  } catch(err) {
-    console.error("Unable to get resource t9n data.")
+  } catch (err) {
+    console.error('Unable to get resource t9n data.');
   }
-
 }
 
 export async function getPortalItemResource(portalItem: __esri.PortalItem): Promise<__esri.PortalItemResource | null> {

--- a/packages/instant-apps-components/src/utils/loadModules.ts
+++ b/packages/instant-apps-components/src/utils/loadModules.ts
@@ -9,7 +9,7 @@
 import { ILoadScriptOptions, loadModules as _loadModules, setDefaultOptions } from 'esri-loader';
 
 export const loadModules = async (moduleNames: string[], options?: ILoadScriptOptions): Promise<any> => {
-  setDefaultOptions({ url: 'https://jsdev.arcgis.com/4.28/' });
+  setDefaultOptions({ url: 'https://js.arcgis.com/4.28/' });
   const mods = await _loadModules(moduleNames, options);
   return mods.map(mod => (mod.__esModule && mod.default ? mod.default : mod));
 };

--- a/packages/instant-apps-components/src/utils/locale.ts
+++ b/packages/instant-apps-components/src/utils/locale.ts
@@ -1,5 +1,5 @@
 // https://medium.com/stencil-tricks/implementing-internationalisation-i18n-with-stencil-5e6559554117
-import { loadModules } from 'esri-loader';
+import { loadModules } from '../utils/loadModules';
 import { languageMap } from './languageUtil';
 
 export function getComponentClosestLanguage(element: HTMLElement): string | undefined {
@@ -41,15 +41,15 @@ function fetchLocaleStringsForComponent<T extends StringBundle = StringBundle>(c
 }
 
 export function getDefaultLanguage(intl: __esri.intl, portal: __esri.Portal): string {
-    // User profile - locale set in user profile
-    const userProfileLocale: string = portal?.get("user.culture");
-    // Browser - window.navigator.language
-    const browserLocale: string = window?.navigator?.language;
-    // ArcGIS JS API - locale currently set in JS api
-    const jsapiLocale: string = intl.getLocale();
-    // Fallback locale - "en"
-    const fallbackLocale = "en";
-    return intl.normalizeMessageBundleLocale(userProfileLocale || browserLocale || jsapiLocale || fallbackLocale) as string;
+  // User profile - locale set in user profile
+  const userProfileLocale: string = portal?.get('user.culture');
+  // Browser - window.navigator.language
+  const browserLocale: string = window?.navigator?.language;
+  // ArcGIS JS API - locale currently set in JS api
+  const jsapiLocale: string = intl.getLocale();
+  // Fallback locale - "en"
+  const fallbackLocale = 'en';
+  return intl.normalizeMessageBundleLocale(userProfileLocale || browserLocale || jsapiLocale || fallbackLocale) as string;
 }
 
 export async function getLocaleComponentStrings<T extends StringBundle = StringBundle>(element: HTMLElement, locale?: string): Promise<[T, string]> {


### PR DESCRIPTION
# Updates

## General
- Use 'loadModules' from src/utils/loadModules
- Update arcgis js api cdn references to 4.28 prod
- - Update calcite components cdn references to v1.9.2

## instant-apps-social-share
- Update projection.loadModules to projection.load
- fix: projection point logic