### PR TITLE
add action option for share

### DIFF
--- a/packages/instant-apps-components/src/components/instant-apps-social-share/instant-apps-social-share.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-social-share/instant-apps-social-share.tsx
@@ -91,7 +91,7 @@ export class InstantAppsSocialShare {
   copyEmbedPopoverRef: HTMLCalcitePopoverElement;
   dialogContentRef: HTMLDivElement | undefined;
   shareListRef: HTMLUListElement | undefined;
-  popoverButtonRef: HTMLCalciteButtonElement | undefined;
+  popoverButtonRef: HTMLCalciteButtonElement | HTMLCalciteActionElement |undefined;
 
   // PUBLIC PROPERTIES
 
@@ -133,6 +133,14 @@ export class InstantAppsSocialShare {
     reflect: true,
   })
   shareButtonColor: 'inverse' | 'neutral' = 'neutral';
+
+  /**
+   * Renders tool in popover mode with a trigger button or action
+   */
+  @Prop({
+    reflect: true,
+  })
+  shareButtonType: 'button' | 'action' = 'button';
 
   /**
    * Text to nest in embed iframe code.
@@ -339,21 +347,7 @@ export class InstantAppsSocialShare {
               >
                 {dialogContent}
               </calcite-popover>,
-              <calcite-button
-                ref={el => (this.popoverButtonRef = el)}
-                onClick={this.togglePopover.bind(this)}
-                id="shareButton"
-                class={CSS.popoverButton}
-                kind={this.shareButtonColor}
-                appearance="transparent"
-                label={this.messages?.share?.label}
-                title={this.messages?.share?.label}
-                scale={this.scale}
-              >
-                <div class={CSS.iconContainer}>
-                  <calcite-icon icon="share" scale={this.popoverButtonIconScale} />
-                </div>
-              </calcite-button>,
+              (this.renderButton()),
             ]
           : [
               dialogContent,
@@ -377,6 +371,42 @@ export class InstantAppsSocialShare {
               </calcite-popover>,
             ]}
       </Host>
+    );
+  }
+
+  renderButton() {
+    return this.shareButtonType === "button" ? (
+      <calcite-button
+        ref={el => (this.popoverButtonRef = el)}
+        onClick={this.togglePopover.bind(this)}
+        id="shareButton"
+        class={CSS.popoverButton}
+        kind={this.shareButtonColor}
+        appearance="transparent"
+        label={this.messages?.share?.label}
+        title={this.messages?.share?.label}
+        scale={this.scale}
+      >
+        <div class={CSS.iconContainer}>
+          <calcite-icon icon="share" scale={this.popoverButtonIconScale} />
+        </div>
+      </calcite-button>
+    ) : (
+      <calcite-action
+        ref={el => (this.popoverButtonRef = el)}
+        onClick={this.togglePopover.bind(this)}
+        id="shareButton"
+        class={CSS.popoverButton}
+        kind={this.shareButtonColor}
+        appearance="transparent"
+        label={this.messages?.share?.label}
+        title={this.messages?.share?.label}
+        scale={this.scale}
+      >
+        <div class={CSS.iconContainer}>
+          <calcite-icon icon="share" scale={this.popoverButtonIconScale} />
+        </div>
+      </calcite-action>
     );
   }
 


### PR DESCRIPTION
The issue is with the difference between how they handle the focus indicator for button vs action in calcite. 

In our app we have a toolbar with various tools that have all been implemented as actions so we can have the hover color fill all the space and then still completely see the focus indicator.

For example this is what the current implementation looks like with a button:
Hover:
![image](https://github.com/Esri/instant-apps-components/assets/2170893/109f814f-49e9-4557-9114-c20b089081a7)

Focus:
![image](https://github.com/Esri/instant-apps-components/assets/2170893/03e315b0-c33f-4d67-a1b9-a4660043d004)

This is what it looks like with the change in this pr when I use the action type:
Hover:
![image](https://github.com/Esri/instant-apps-components/assets/2170893/22a9c922-a0b3-405b-b939-e8edb80f2fd6)

Focus:
![image](https://github.com/Esri/instant-apps-components/assets/2170893/b6b9769e-2b79-4b53-a088-5c94a92fa576)


