### PR TITLE
fix: Update logic to not try to get the selected feature if its not a…

### DIFF
--- a/packages/instant-apps-components/src/components/instant-apps-social-share/instant-apps-social-share.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-social-share/instant-apps-social-share.tsx
@@ -822,19 +822,20 @@ export class InstantAppsSocialShare {
     const visible = this.view?.popup?.visible;
     let layerId;
     let oid;
-    if (graphic && visible) {
+    let hiddenLayers;
+    if (graphic && visible && graphic?.layer?.type === 'feature') {
       const featureLayer = graphic?.layer as __esri.FeatureLayer;
-      layerId = featureLayer.id;
+
+      layerId = featureLayer?.id;
       oid = graphic.attributes[featureLayer.objectIdField];
+
+      hiddenLayers = this.view.map.allLayers
+        .filter(layer => !layer.visible)
+        .toArray()
+        .map(featureLayer => featureLayer.id)
+        .toString()
+        .replaceAll(',', ';');
     }
-
-    const hiddenLayers = this.view.map.allLayers
-      .filter(layer => !layer.visible)
-      .toArray()
-      .map(featureLayer => featureLayer.id)
-      .toString()
-      .replaceAll(',', ';');
-
     const { type } = this.view;
     const { defaultUrlParams } = this;
 


### PR DESCRIPTION
When testing the streamflow app that has layers based on a map image layer the share was failing when trying to share the selected feature. Looks like share is currently only setup to work with feature layers and was erroring out if the selected features layer is an image layer.  
