### PR TITLE
fix: change fieldName to uid for textEditor onChange

### DIFF
--- a/packages/instant-apps-components/CHANGELOG.md
+++ b/packages/instant-apps-components/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.0-beta.252
+
+### instant-apps-language-translator-item
+
+- fix: change fieldName to uid for textEditor onChange
+
 ## v1.0.0-beta.251
 
 ### instant-apps-filter-list

--- a/packages/instant-apps-components/package.json
+++ b/packages/instant-apps-components/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://esri.github.io/instant-apps-components",
   "name": "@esri/instant-apps-components",
-  "version": "1.0.0-beta.251",
+  "version": "1.0.0-beta.252",
   "description": "Reusable ArcGIS Instant Apps web components.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/instant-apps-components/src/components/instant-apps-language-translator/instant-apps-language-translator-item/instant-apps-language-translator-item.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-language-translator/instant-apps-language-translator-item/instant-apps-language-translator-item.tsx
@@ -445,9 +445,11 @@ export class InstantAppsLanguageTranslatorItem {
     store.set('saving', true);
     try {
       const value = e.detail;
+      const node = e.target as HTMLInstantAppsCkeditorWrapperElement;
+      const uid = node.id;
       const uiDataItem = this.getUIDataItem() as LocaleSettingItem;
       uiDataItem.userLocaleData.value = value;
-      await this.userLocaleInputOnChangeCallback(this.fieldName, value);
+      await this.userLocaleInputOnChangeCallback(uid, value);
       store.set('saving', false);
     } catch {
       store.set('saving', false);


### PR DESCRIPTION
fieldName being there instead of the full id causes issues in translator