### PR TITLE
chore: add unit tests for the App Guide component

### DIFF
--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/instant-apps-app-guide.test.ts
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/instant-apps-app-guide.test.ts
@@ -58,9 +58,8 @@ describe('Instant Apps App Guide', async () => {
     });
 
     test('instant-apps-app-guide has fallback header text', async () => {
-      const { shadowRoot: shadowRoot2 } = await _createAppGuideComponent([testPages.emptyTitle]);
-      console.log(shadowRoot2?.innerHTML);
-      const headerSpan = shadowRoot2?.querySelector('[slot="header-content"]');
+      const { shadowRoot: _shadowRoot } = await _createAppGuideComponent([testPages.emptyTitle]);
+      const headerSpan = _shadowRoot?.querySelector('[slot="header-content"]');
       expect(headerSpan).toBeDefined();
       expect(headerSpan?.textContent?.trim()).toBe('Tips');
     });
@@ -76,7 +75,7 @@ describe('Instant Apps App Guide', async () => {
     const header = false;
     const { appGuide, shadowRoot } = await _createAppGuideComponent([testPages.singleParagraph], header);
 
-    test('instant-apps-app-guide has no header', () => {
+    test('instant-apps-app-guide has no header span', () => {
       const headerSpan = shadowRoot?.querySelector('[slot="header-content"]');
       expect(headerSpan).toBeNull();
       expect(appGuide.header).toBeFalsy();

--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/instant-apps-app-guide.test.ts
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/instant-apps-app-guide.test.ts
@@ -46,6 +46,9 @@ describe('Instant Apps App Guide', async () => {
     });
 
     test('instant-apps-app-guide has paragraph content', () => {
+      const wrapper = shadowRoot?.querySelector('.instant-apps-app-guide__content-wrapper');
+      expect(wrapper).toBeDefined();
+
       const content = shadowRoot?.querySelector('p');
       expect(content).toBeDefined();
       expect(content?.textContent).toBe('Test Content');
@@ -118,6 +121,16 @@ describe('Instant Apps App Guide', async () => {
       await new Promise(resolve => requestIdleCallback(resolve));
       const headerSpan = shadowRoot?.querySelector('[slot="header-content"]');
       expect(headerSpan?.textContent?.trim()).toBe('Test Title 2');
+    });
+  });
+
+  describe('component with list content', async () => {
+    const { shadowRoot } = await _createAppGuideComponent([testPages.list]);
+
+    test('instant-apps-app-guide has list content', () => {
+      const list = shadowRoot?.querySelector('.instant-apps-app-guide__content-list');
+      expect(list).toBeDefined();
+      expect(list?.querySelectorAll('.instant-apps-app-guide__content-list--item')).toHaveLength(3);
     });
   });
 });

--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/instant-apps-app-guide.test.ts
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/instant-apps-app-guide.test.ts
@@ -1,0 +1,68 @@
+import { expect, test, describe } from 'vitest';
+import { waitForShadowRoot } from '../../../utils/testUtils.js';
+
+import '../../../../dist/components/instant-apps-app-guide.js';
+import { AppGuidePage } from '../AppGuide/interfaces/interfaces.js';
+import testPages from './testdata';
+
+const _createAppGuideComponent = async (data:AppGuidePage[], hasHeader: boolean = false ) => {
+  const appGuide = document.createElement('instant-apps-app-guide');
+  if (hasHeader) appGuide.setAttribute('header', '');
+  appGuide.data = data;
+  document.body.appendChild(appGuide);
+
+  await new Promise(resolve => requestIdleCallback(resolve));
+  const shadowRoot = await waitForShadowRoot(appGuide);
+
+  return { appGuide, shadowRoot };
+}
+
+describe('Instant Apps App Guide', async () => {
+  describe('default component', async () => {
+    const { appGuide, shadowRoot } = await _createAppGuideComponent([testPages.singleParagraph]);
+
+    test('instant-apps-app-guide is defined', () => {
+      expect(appGuide).toBeDefined();
+    });
+  
+    test('instant-apps-app-guide has shadowRoot', () => {
+      expect(shadowRoot).toBeDefined();
+    });
+
+    test('instant-apps-app-guide has data assigned', () => {
+      expect(appGuide.data).toEqual([
+        {
+          title: 'Test Title',
+          content: ['Test Content'],
+          type: 'paragraphs'
+        }
+      ]);
+    });
+
+    test('instant-apps-app-guide has no header attribute', () => {
+      expect(appGuide.hasAttribute('header')).toBeFalsy();
+    });
+
+    test('instant-apps-app-guide has paragraph content', () => {
+      const content = shadowRoot?.querySelector('p');
+      expect(content).toBeDefined();
+      expect(content?.textContent).toBe('Test Content');
+    });
+  }); 
+
+  describe('component with header', async () => {
+    const useHeader = true;
+    const { appGuide, shadowRoot } = await _createAppGuideComponent([testPages.singleParagraph], useHeader);
+
+    test('instant-apps-app-guide has header attribute', () => {
+      expect(appGuide.hasAttribute('header')).toBeTruthy();
+      expect(appGuide.header).toBeTruthy();
+    });
+
+    test('instant-apps-app-guide has header text', () => {
+      const headerSpan = shadowRoot?.querySelector('[slot="header-content"]');
+      expect(headerSpan).toBeDefined();
+      expect(headerSpan?.textContent?.trim()).toBe('Test Title');
+    });
+  });
+});

--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/instant-apps-app-guide.test.ts
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/instant-apps-app-guide.test.ts
@@ -98,7 +98,7 @@ describe('Instant Apps App Guide', async () => {
 
   describe('component with three or more pages', async () => {
     const pages = [testPages.singleParagraph, testPages.paragraphs, testPages.list];
-    const { shadowRoot } = await _createAppGuideComponent(pages);
+    const { appGuide, shadowRoot } = await _createAppGuideComponent(pages);
 
     test(`instant-apps-app-guide has ${pages.length} pages`, () => {
       const pages = shadowRoot?.querySelectorAll('calcite-carousel-item');
@@ -108,6 +108,16 @@ describe('Instant Apps App Guide', async () => {
     test('instant-apps-app-guide has arrow type "inline"', () => {
       const arrowType = shadowRoot?.querySelector('calcite-carousel')?.getAttribute('arrow-type');
       expect(arrowType).toBe('inline');
+    });
+
+    test('instant-apps-app-guide header text updates with data changes', async () => {
+      // Data changes trigger _updateHeaderText() and so does the onCalciteCarouselChange
+      // event handler; we'll use this as a proxy for paging through the carousel
+      // since can't actually do that from the Shadow DOM
+      appGuide.data = appGuide.data.slice(1);
+      await new Promise(resolve => requestIdleCallback(resolve));
+      const headerSpan = shadowRoot?.querySelector('[slot="header-content"]');
+      expect(headerSpan?.textContent?.trim()).toBe('Test Title 2');
     });
   });
 });

--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/instant-apps-app-guide.test.ts
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/instant-apps-app-guide.test.ts
@@ -57,6 +57,14 @@ describe('Instant Apps App Guide', async () => {
       expect(headerSpan?.textContent?.trim()).toBe('Test Title');
     });
 
+    test('instant-apps-app-guide has fallback header text', async () => {
+      const { shadowRoot: shadowRoot2 } = await _createAppGuideComponent([testPages.emptyTitle]);
+      console.log(shadowRoot2?.innerHTML);
+      const headerSpan = shadowRoot2?.querySelector('[slot="header-content"]');
+      expect(headerSpan).toBeDefined();
+      expect(headerSpan?.textContent?.trim()).toBe('Tips');
+    });
+
     test('instant-apps-app-guide has header with lightbulb icon', () => {
       const headerIcon = shadowRoot?.querySelector('calcite-icon');
       expect(headerIcon).toBeDefined();
@@ -72,6 +80,35 @@ describe('Instant Apps App Guide', async () => {
       const headerSpan = shadowRoot?.querySelector('[slot="header-content"]');
       expect(headerSpan).toBeNull();
       expect(appGuide.header).toBeFalsy();
+    });
+  });
+
+  describe('component with two pages', async () => {
+    const { shadowRoot } = await _createAppGuideComponent([testPages.singleParagraph, testPages.paragraphs]);
+
+    test('instant-apps-app-guide has 2 pages', () => {
+      const pages = shadowRoot?.querySelectorAll('calcite-carousel-item');
+      expect(pages).toHaveLength(2);
+    });
+
+    test('instant-apps-app-guide has arrow type "none"', () => {
+      const arrowType = shadowRoot?.querySelector('calcite-carousel')?.getAttribute('arrow-type');
+      expect(arrowType).toBe('none');
+    });
+  });
+
+  describe('component with three or more pages', async () => {
+    const pages = [testPages.singleParagraph, testPages.paragraphs, testPages.list];
+    const { shadowRoot } = await _createAppGuideComponent(pages);
+
+    test(`instant-apps-app-guide has ${pages.length} pages`, () => {
+      const pages = shadowRoot?.querySelectorAll('calcite-carousel-item');
+      expect(pages).toHaveLength(pages?.length as number);
+    });
+
+    test('instant-apps-app-guide has arrow type "inline"', () => {
+      const arrowType = shadowRoot?.querySelector('calcite-carousel')?.getAttribute('arrow-type');
+      expect(arrowType).toBe('inline');
     });
   });
 });

--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/instant-apps-app-guide.test.ts
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/instant-apps-app-guide.test.ts
@@ -5,9 +5,10 @@ import '../../../../dist/components/instant-apps-app-guide.js';
 import { AppGuidePage } from '../AppGuide/interfaces/interfaces.js';
 import testPages from './testdata';
 
-const _createAppGuideComponent = async (data:AppGuidePage[], hasHeader: boolean = false ) => {
+const _createAppGuideComponent = async (data:AppGuidePage[], header?: boolean ) => {
   const appGuide = document.createElement('instant-apps-app-guide');
-  if (hasHeader) appGuide.setAttribute('header', '');
+
+  appGuide.header = header ?? true;
   appGuide.data = data;
   document.body.appendChild(appGuide);
 
@@ -19,6 +20,7 @@ const _createAppGuideComponent = async (data:AppGuidePage[], hasHeader: boolean 
 
 describe('Instant Apps App Guide', async () => {
   describe('default component', async () => {
+
     const { appGuide, shadowRoot } = await _createAppGuideComponent([testPages.singleParagraph]);
 
     test('instant-apps-app-guide is defined', () => {
@@ -39,8 +41,8 @@ describe('Instant Apps App Guide', async () => {
       ]);
     });
 
-    test('instant-apps-app-guide has no header attribute', () => {
-      expect(appGuide.hasAttribute('header')).toBeFalsy();
+    test('instant-apps-app-guide header property has been set', () => {
+      expect(appGuide.header).toBeTruthy();
     });
 
     test('instant-apps-app-guide has paragraph content', () => {
@@ -48,21 +50,28 @@ describe('Instant Apps App Guide', async () => {
       expect(content).toBeDefined();
       expect(content?.textContent).toBe('Test Content');
     });
-  }); 
 
-  describe('component with header', async () => {
-    const useHeader = true;
-    const { appGuide, shadowRoot } = await _createAppGuideComponent([testPages.singleParagraph], useHeader);
-
-    test('instant-apps-app-guide has header attribute', () => {
-      expect(appGuide.hasAttribute('header')).toBeTruthy();
-      expect(appGuide.header).toBeTruthy();
-    });
-
-    test('instant-apps-app-guide has header text', () => {
+    test('instant-apps-app-guide has header with text', () => {
       const headerSpan = shadowRoot?.querySelector('[slot="header-content"]');
       expect(headerSpan).toBeDefined();
       expect(headerSpan?.textContent?.trim()).toBe('Test Title');
+    });
+
+    test('instant-apps-app-guide has header with lightbulb icon', () => {
+      const headerIcon = shadowRoot?.querySelector('calcite-icon');
+      expect(headerIcon).toBeDefined();
+      expect(headerIcon?.getAttribute('icon')).toBe('lightbulb');
+    });
+  }); 
+
+  describe('component with no header', async () => {
+    const header = false;
+    const { appGuide, shadowRoot } = await _createAppGuideComponent([testPages.singleParagraph], header);
+
+    test('instant-apps-app-guide has no header', () => {
+      const headerSpan = shadowRoot?.querySelector('[slot="header-content"]');
+      expect(headerSpan).toBeNull();
+      expect(appGuide.header).toBeFalsy();
     });
   });
 });

--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/testdata.ts
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/testdata.ts
@@ -1,0 +1,21 @@
+import { AppGuidePage } from '../AppGuide/interfaces/interfaces.js';
+
+const singleParagraph:AppGuidePage = {
+  title: 'Test Title',
+  content: ['Test Content'],
+  type: 'paragraphs'
+};
+
+const list:AppGuidePage = {
+  title: 'Test Title',
+  content: ['Test Content 1', 'Test Content 2', 'Test Content 3'],
+  type: 'list'
+};
+
+const paragraphs:AppGuidePage = {
+  title: 'Test Title',
+  content: ['Test Content 1', 'Test Content 2'],
+  type: 'paragraphs'
+};
+
+export default { singleParagraph, list, paragraphs };

--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/testdata.ts
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/testdata.ts
@@ -18,4 +18,10 @@ const paragraphs:AppGuidePage = {
   type: 'paragraphs'
 };
 
-export default { singleParagraph, list, paragraphs };
+const emptyTitle:AppGuidePage = {
+  title: '',
+  content: ['Generic Tip 1', 'Generic Tip 2'],
+  type: 'paragraphs'
+};
+
+export default { singleParagraph, list, paragraphs, emptyTitle };

--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/testdata.ts
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/__tests__/testdata.ts
@@ -7,13 +7,13 @@ const singleParagraph:AppGuidePage = {
 };
 
 const list:AppGuidePage = {
-  title: 'Test Title',
+  title: 'Test Title 3',
   content: ['Test Content 1', 'Test Content 2', 'Test Content 3'],
   type: 'list'
 };
 
 const paragraphs:AppGuidePage = {
-  title: 'Test Title',
+  title: 'Test Title 2',
   content: ['Test Content 1', 'Test Content 2'],
   type: 'paragraphs'
 };

--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/instant-apps-app-guide.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/instant-apps-app-guide.tsx
@@ -96,8 +96,12 @@ export class InstantAppsAppGuide {
   }
 
   private _renderAppGuideHeader() {
-    return !!this.header && this.messages?.headerText ?
-      (<span slot="header-content">{this.headerText} <calcite-icon icon="lightbulb" scale="s"></calcite-icon></span>) :
+    const { messages, header, headerText } = this;
+    const displayHeader = !!header && messages?.headerText;
+    const _headerText = headerText || messages?.headerText;
+
+    return displayHeader ?
+      (<span slot="header-content">{_headerText} <calcite-icon icon="lightbulb" scale="s"></calcite-icon></span>) :
       null;
   }
 

--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/instant-apps-app-guide.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/instant-apps-app-guide.tsx
@@ -80,15 +80,16 @@ export class InstantAppsAppGuide {
   }
 
   private _updateHeaderText() {
-    const nodeArray = Array.from(this._carouselRef.childNodes);
-    const selectedNodeIndex = nodeArray.indexOf(this._carouselRef.selectedItem);
+    const { _viewModel, _carouselRef, messages } = this;
+    const nodeArray = Array.from(_carouselRef.childNodes);
+    const selectedNodeIndex = nodeArray.indexOf(_carouselRef.selectedItem);
 
     // DOM nodes get updated after the viewModel is updated, so the selectedNodeIndex
     // may be out of bounds of the pages collection in the viewModel when pages are removed.
     // When this happens, we default to the title of the first page.
-    const pages = this._viewModel?.pages;
+    const pages = _viewModel?.pages;
     const selectedPage = pages?.[selectedNodeIndex] ?? pages[0];
-    this.headerText = selectedPage?.title || this?.messages?.headerText;
+    this.headerText = selectedPage?.title || messages?.headerText;
   }
 
   private _getArrowType(): ArrowType {

--- a/packages/instant-apps-components/src/instant-apps-app-guide.html
+++ b/packages/instant-apps-components/src/instant-apps-app-guide.html
@@ -90,7 +90,6 @@
     const appGuide = document.createElement("instant-apps-app-guide");
 
     appGuide.data = [compassTool, searchTool, tryItOut];
-    appGuide.header = true;
     appGuidePlacement.appendChild(appGuide);
   </script>
 </body>


### PR DESCRIPTION
## Tests
```            
 ✓ instant-apps-app-guide is defined                  
 ✓ instant-apps-app-guide has shadowRoot              
 ✓ instant-apps-app-guide has data assigned           
 ✓ instant-apps-app-guide header property has been set
 ✓ instant-apps-app-guide has paragraph content
 ✓ instant-apps-app-guide has header with text
 ✓ instant-apps-app-guide has fallback header text
 ✓ instant-apps-app-guide has header with lightbulb icon

 ✓ instant-apps-app-guide has no header span

 ✓ instant-apps-app-guide has 2 pages
 ✓ instant-apps-app-guide has arrow type "none"

 ✓ instant-apps-app-guide has 3 pages
 ✓ instant-apps-app-guide has arrow type "inline"
 ✓ instant-apps-app-guide header text updates with data changes

 ✓ instant-apps-app-guide has list content
```