### PR TITLE
chore: update `selectedLanguage` to a prop

### DIFF
--- a/packages/instant-apps-components/CHANGELOG.md
+++ b/packages/instant-apps-components/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.0-beta.267
+
+### instant-apps-language-switcher
+
+- update `selectedLanguage` to a prop
+
 ## v1.0.0-beta.266
 
 ### instant-apps-app-guide

--- a/packages/instant-apps-components/package-lock.json
+++ b/packages/instant-apps-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@esri/instant-apps-components",
-  "version": "1.0.0-beta.266",
+  "version": "1.0.0-beta.267",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@esri/instant-apps-components",
-      "version": "1.0.0-beta.266",
+      "version": "1.0.0-beta.267",
       "dependencies": {
         "@a11y/focus-trap": "^1.0.5",
         "@arcgis/core": ">=4.31.0-next.20240624 <4.32",

--- a/packages/instant-apps-components/package.json
+++ b/packages/instant-apps-components/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://esri.github.io/instant-apps-components",
   "name": "@esri/instant-apps-components",
-  "version": "1.0.0-beta.266",
+  "version": "1.0.0-beta.267",
   "description": "Reusable ArcGIS Instant Apps web components.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/instant-apps-components/src/components.d.ts
+++ b/packages/instant-apps-components/src/components.d.ts
@@ -587,6 +587,10 @@ export namespace Components {
          */
         "refresh": () => Promise<void>;
         /**
+          * The currently selected language.
+         */
+        "selectedLanguage": string | null;
+        /**
           * Reference to map view to switch web maps if present in locales.
          */
         "view"?: __esri.MapView | __esri.SceneView;
@@ -2009,6 +2013,10 @@ declare namespace LocalJSX {
           * Instant App portal item - used to fetch it's associated portal item resource. The portal item resource will contain the user defined translated strings.
          */
         "portalItem": __esri.PortalItem;
+        /**
+          * The currently selected language.
+         */
+        "selectedLanguage"?: string | null;
         /**
           * Reference to map view to switch web maps if present in locales.
          */

--- a/packages/instant-apps-components/src/components/instant-apps-language-switcher/instant-apps-language-switcher.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-language-switcher/instant-apps-language-switcher.tsx
@@ -54,11 +54,14 @@ export class InstantAppsLanguageSwitcher {
   @Prop()
   defaultLocale?: string;
 
-  @State()
-  messages: typeof LanguageTranslator_t9n;
+  /**
+    The currently selected language.
+   */
+  @Prop()
+  selectedLanguage: string | null = null;
 
   @State()
-  selectedLanguage: string | null = null;
+  messages: typeof LanguageTranslator_t9n;
 
   @State()
   t9nData: any = null;

--- a/packages/instant-apps-components/src/components/instant-apps-language-switcher/readme.md
+++ b/packages/instant-apps-components/src/components/instant-apps-language-switcher/readme.md
@@ -55,13 +55,14 @@ document.addEventListener("selectedLanguageUpdated", (e: CustomEvent) => {
 
 ## Properties
 
-| Property                  | Attribute        | Description                                                                                                                                              | Type                                                  | Default      |
-| ------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------ |
-| `defaultLocale`           | `default-locale` | Defines the default language of the language switcher dropdown. Set internally if not defined.                                                           | `string \| undefined`                                 | `undefined`  |
-| `icon`                    | `icon`           | Icon to display.                                                                                                                                         | `string`                                              | `'language'` |
-| `locales`                 | --               | Data used to populate language switcher dropdown.                                                                                                        | `{ locale: string; webmap?: string \| undefined; }[]` | `[]`         |
-| `portalItem` _(required)_ | --               | Instant App portal item - used to fetch it's associated portal item resource. The portal item resource will contain the user defined translated strings. | `PortalItem`                                          | `undefined`  |
-| `view`                    | --               | Reference to map view to switch web maps if present in locales.                                                                                          | `MapView \| SceneView \| undefined`                   | `undefined`  |
+| Property                  | Attribute           | Description                                                                                                                                              | Type                                                  | Default      |
+| ------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------ |
+| `defaultLocale`           | `default-locale`    | Defines the default language of the language switcher dropdown. Set internally if not defined.                                                           | `string \| undefined`                                 | `undefined`  |
+| `icon`                    | `icon`              | Icon to display.                                                                                                                                         | `string`                                              | `'language'` |
+| `locales`                 | --                  | Data used to populate language switcher dropdown.                                                                                                        | `{ locale: string; webmap?: string \| undefined; }[]` | `[]`         |
+| `portalItem` _(required)_ | --                  | Instant App portal item - used to fetch it's associated portal item resource. The portal item resource will contain the user defined translated strings. | `PortalItem`                                          | `undefined`  |
+| `selectedLanguage`        | `selected-language` | The currently selected language.                                                                                                                         | `null \| string`                                      | `null`       |
+| `view`                    | --                  | Reference to map view to switch web maps if present in locales.                                                                                          | `MapView \| SceneView \| undefined`                   | `undefined`  |
 
 
 ## Events


### PR DESCRIPTION
Need to change `selectedLanguage` to a prop so it can be updated. LanguageSwitcher is added to the view in Exhibit, an app with multiple views, so need to be able to update the `selectedLanguage` in the other views.