### PR TITLE
fix: App Guide header styling

### DIFF
--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/instant-apps-app-guide.scss
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/instant-apps-app-guide.scss
@@ -24,13 +24,7 @@
     display: flex;
     gap: var(--calcite-spacing-sm);
     padding-inline-start: 0.25rem;
-  }
-
-  .content-heading {
     font-weight: var(--calcite-font-weight-bold);
-    display: flex;
-    gap: var(--calcite-spacing-sm);
-    line-height: var(--calcite-font-line-height-fixed-lg);
   }
 
   calcite-carousel-item {


### PR DESCRIPTION
Makes the text in the component header bold

![Screenshot 2024-10-04 at 10 20 09 AM](https://github.com/user-attachments/assets/d5846a79-7b08-433d-b993-c7a92b14916a)
