### PR TITLE
fix: app guide scrollbar defaults

### DIFF
--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/instant-apps-app-guide.scss
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/instant-apps-app-guide.scss
@@ -15,9 +15,9 @@
 
   calcite-carousel {
     flex: 1;
-    overflow: scroll;
     height: fit-content;
     background-color: var(--calcite-color-foreground-1);
+    overflow: auto;
   }
 
   [slot='header-content'] {


### PR DESCRIPTION
Ensure that scrollbars on the App Guide component only show up when they are needed.