### PR TITLE
feat: Add an option to set a max height for the content area

### DIFF
--- a/packages/instant-apps-components/src/components/instant-apps-splash/instant-apps-splash.scss
+++ b/packages/instant-apps-components/src/components/instant-apps-splash/instant-apps-splash.scss
@@ -1,4 +1,9 @@
+/*
+* @prop --instant-apps-splash-content-max-height: Set the max height of the content area .
+*/
+
 :host {
+  --instant-apps-splash-content-max-height: 100%;
   display: block;
 
   .image.image_resized {
@@ -14,5 +19,9 @@
     calcite-label {
       --calcite-label-margin-bottom: 0;
     }
+  }
+
+  .instant-apps-splash__content {
+    max-height: var(--instant-apps-splash-content-max-height);
   }
 }

--- a/packages/instant-apps-components/src/components/instant-apps-splash/instant-apps-splash.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-splash/instant-apps-splash.tsx
@@ -7,6 +7,7 @@ import Splash_T9n from '../../assets/t9n/instant-apps-splash/resources.json';
 
 const CSS = {
   back: 'instant-apps-splash__back-content',
+  content: 'instant-apps-splash__content',
 };
 
 @Component({
@@ -137,7 +138,7 @@ export class InstantAppsSplash {
   renderContent(): HTMLElement {
     const { content } = this;
     return (
-      <div slot="content" innerHTML={content}>
+      <div slot="content" class={CSS.content} innerHTML={content}>
         <slot name="custom-action"></slot>
       </div>
     );

--- a/packages/instant-apps-components/src/components/instant-apps-splash/readme.md
+++ b/packages/instant-apps-components/src/components/instant-apps-splash/readme.md
@@ -10,7 +10,6 @@ In the splash tool there is a check box that allows users to “Don’t show thi
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property                       | Attribute                | Description                                                                                              | Type                  | Default     |
@@ -27,17 +26,20 @@ In the splash tool there is a check box that allows users to “Don’t show thi
 | `secondaryButtonText`          | `secondary-button-text`  | Secondary button text.                                                                                   | `string`              | `undefined` |
 | `titleText`                    | `title-text`             | Title of splash screen.                                                                                  | `string`              | `''`        |
 
-
 ## Events
 
 | Event         | Description                            | Type                |
 | ------------- | -------------------------------------- | ------------------- |
 | `splashClose` | Emits when the splash modal is closed. | `CustomEvent<void>` |
 
+---
 
-----------------------------------------------
+## CSS Custom Properties
+
+| ` --instant-apps-splash-content-max-height` | Max height of content area. |
 
 ## License
+
 COPYRIGHT © 2024 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
@@ -49,4 +51,3 @@ See use restrictions at http://www.esri.com/legal/pdfs/mla_e204_e300/english
 For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
 
 email: contracts@esri.com
-


### PR DESCRIPTION
 @rslibed 

In some of my apps if there is a lot of content in the info window it ends up taking up the full height of the app and in some cases it looks odd based on the app design. It would be great if we could have a css variable that allows app devs to limit the max height of the content area. I added one in this PR. Feel free to review, change the names or let me know if this isn't the best approach for this component. 