### PR TITLE
fix: update App Guide component to work with Calcite 3

### DIFF
--- a/packages/instant-apps-components/package-lock.json
+++ b/packages/instant-apps-components/package-lock.json
@@ -12,7 +12,7 @@
         "@arcgis/core": ">=4.32.0-next.20241010 <4.33",
         "@ckeditor/ckeditor5-build-classic": "^39.0.1",
         "@esri/arcgis-html-sanitizer": "^4.0.3",
-        "@esri/calcite-components": "2.13.0",
+        "@esri/calcite-components": "3.0.0-next.40",
         "@stencil/core": "4.17.1",
         "@stencil/react-output-target": "^0.5.3",
         "@stencil/store": "^2.0.8",
@@ -76,6 +76,25 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@arcgis/components-controllers": {
+      "version": "4.32.0-next.29",
+      "resolved": "https://registry.npmjs.org/@arcgis/components-controllers/-/components-controllers-4.32.0-next.29.tgz",
+      "integrity": "sha512-l23HJWuNYe3pdnLv3GIxdvwWF3tR7QQNGoJKuULxlXGqXavd0Tk7D5g+hSUYJ4Er3ymq2XgFLXvIOmS02L9P5w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@arcgis/components-utils": "4.32.0-next.29",
+        "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/@arcgis/components-utils": {
+      "version": "4.32.0-next.29",
+      "resolved": "https://registry.npmjs.org/@arcgis/components-utils/-/components-utils-4.32.0-next.29.tgz",
+      "integrity": "sha512-9DQcIvWZD6lTKC+/ImV/VmY6sc+2RWnaVQJLRLn9qeiJ2GpkWnGRw06projqAgLSRYF1f7jD+EZVuX0+s0SQ2g==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      }
+    },
     "node_modules/@arcgis/core": {
       "version": "4.32.0-next.20241202",
       "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.32.0-next.20241202.tgz",
@@ -100,6 +119,57 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@arcgis/core/node_modules/@esri/calcite-components": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.13.2.tgz",
+      "integrity": "sha512-90v4H8zs2wEzUXQGmZ+joHhP7ulFUHmQjDlIwXylJiDvoChhnEm38iv7eeG+X8im06biIHEDGRB8LLszlQQ7jw==",
+      "license": "SEE LICENSE.md",
+      "dependencies": {
+        "@esri/calcite-ui-icons": "3.32.0",
+        "@floating-ui/dom": "1.6.11",
+        "@stencil/core": "4.20.0",
+        "@types/color": "3.0.6",
+        "@types/sortablejs": "1.15.8",
+        "color": "4.2.3",
+        "composed-offset-position": "0.0.6",
+        "dayjs": "1.11.13",
+        "focus-trap": "7.6.0",
+        "interactjs": "1.10.27",
+        "lodash-es": "4.17.21",
+        "sortablejs": "1.15.3",
+        "timezone-groups": "0.10.2",
+        "type-fest": "4.18.2"
+      }
+    },
+    "node_modules/@arcgis/core/node_modules/@stencil/core": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.20.0.tgz",
+      "integrity": "sha512-WPrTHFngvN081RY+dJPneKQLwnOFD60OMCOQGmmSHfCW0f4ujPMzzhwWU1gcSwXPWXz5O+8cBiiCaxAbJU7kAg==",
+      "license": "MIT",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
+      }
+    },
+    "node_modules/@arcgis/lumina": {
+      "version": "4.32.0-next.29",
+      "resolved": "https://registry.npmjs.org/@arcgis/lumina/-/lumina-4.32.0-next.29.tgz",
+      "integrity": "sha512-j3bRiTf1VYUPPKG+P2fEGCtDoA1N8lxAK0I5BlbQv1jS8fk+iPAHqMeLwf6FKN9EJhyFlBc010qQ2CVMkPKkMA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@arcgis/components-controllers": "4.32.0-next.29",
+        "@arcgis/components-utils": "4.32.0-next.29",
+        "@lit-labs/ssr": "^3.2.2",
+        "@lit-labs/ssr-client": "^1.1.7",
+        "@lit/context": "^1.1.3",
+        "csstype": "^3.1.3",
+        "lit": "^3.2.0",
+        "tslib": "^2.7.0"
       }
     },
     "node_modules/@aw-web-design/x-default-browser": {
@@ -2781,19 +2851,23 @@
       "integrity": "sha512-wHQYWFtDa6c328EraXEVZvgOiaQyYr0yuaaZ0G3cB4C3lSkWefW34L/e5TLAhtuG3zJ/wR6pl5X1YYNfBc0/4Q=="
     },
     "node_modules/@esri/calcite-components": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.13.0.tgz",
-      "integrity": "sha512-szlPLr4RjxegU9Bvxwf4/U2ciI2zJdoDpW7/A7353nz5x+bJJa3GvwEYyuye533faC9p2KoGpEXcB/8susISIg==",
+      "version": "3.0.0-next.40",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-3.0.0-next.40.tgz",
+      "integrity": "sha512-SPepQDk2SgTBX9PLSQMCfZ+1+wpfrqQHBUnAYOExIzFojOHT4mdPkHTEjf731djsyTYWcWK9sy030l2vDDJd+g==",
+      "license": "SEE LICENSE.md",
       "dependencies": {
-        "@esri/calcite-ui-icons": "3.32.0",
-        "@floating-ui/dom": "1.6.11",
-        "@stencil/core": "4.20.0",
+        "@arcgis/components-controllers": "4.32.0-next.29",
+        "@arcgis/components-utils": "4.32.0-next.29",
+        "@arcgis/lumina": "4.32.0-next.29",
+        "@esri/calcite-ui-icons": "4.0.0-next.1",
+        "@floating-ui/dom": "1.6.12",
+        "@floating-ui/utils": "0.2.8",
         "@types/color": "3.0.6",
         "@types/sortablejs": "1.15.8",
         "color": "4.2.3",
         "composed-offset-position": "0.0.6",
         "dayjs": "1.11.13",
-        "focus-trap": "7.6.0",
+        "focus-trap": "7.6.2",
         "interactjs": "1.10.27",
         "lodash-es": "4.17.21",
         "sortablejs": "1.15.3",
@@ -2801,22 +2875,39 @@
         "type-fest": "4.18.2"
       }
     },
-    "node_modules/@esri/calcite-components/node_modules/@stencil/core": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.20.0.tgz",
-      "integrity": "sha512-WPrTHFngvN081RY+dJPneKQLwnOFD60OMCOQGmmSHfCW0f4ujPMzzhwWU1gcSwXPWXz5O+8cBiiCaxAbJU7kAg==",
+    "node_modules/@esri/calcite-components/node_modules/@esri/calcite-ui-icons": {
+      "version": "4.0.0-next.1",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-4.0.0-next.1.tgz",
+      "integrity": "sha512-4krcnVRSAXsGZr2BYk+jwXK4eWZw+ZooK1DuQavPjU5n/LEIK9/nMHlv4O/Nhahw4zoUE795LO7MGAsMAuLHHg==",
+      "license": "SEE LICENSE.md",
       "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.10.0"
+        "spriter": "bin/spriter.js"
+      }
+    },
+    "node_modules/@esri/calcite-components/node_modules/@floating-ui/dom": {
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
+      "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.8"
+      }
+    },
+    "node_modules/@esri/calcite-components/node_modules/focus-trap": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
+      "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.2.0"
       }
     },
     "node_modules/@esri/calcite-ui-icons": {
       "version": "3.32.0",
       "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.32.0.tgz",
       "integrity": "sha512-2UEddEeSnpXVWp/uNrgym3mrb8lZ5+vXFbtmvXv5NiE32nQGw2MFZD52L5Z+FsxqHJ9vVrtl/X6pTIgkd0c8jA==",
+      "license": "SEE LICENSE.md",
       "bin": {
         "spriter": "bin/spriter.js"
       }
@@ -3325,10 +3416,103 @@
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
       "dev": true
     },
+    "node_modules/@lit-labs/ssr": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr/-/ssr-3.2.2.tgz",
+      "integrity": "sha512-He5TzeNPM9ECmVpgXRYmVlz0UA5YnzHlT43kyLi2Lu6mUidskqJVonk9W5K699+2DKhoXp8Ra4EJmHR6KrcW1Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-client": "^1.1.7",
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "@parse5/tools": "^0.3.0",
+        "@types/node": "^16.0.0",
+        "enhanced-resolve": "^5.10.0",
+        "lit": "^3.1.2",
+        "lit-element": "^4.0.4",
+        "lit-html": "^3.1.2",
+        "node-fetch": "^3.2.8",
+        "parse5": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=13.9.0"
+      }
+    },
+    "node_modules/@lit-labs/ssr-client": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-client/-/ssr-client-1.1.7.tgz",
+      "integrity": "sha512-VvqhY/iif3FHrlhkzEPsuX/7h/NqnfxLwVf0p8ghNIlKegRyRqgeaJevZ57s/u/LiFyKgqksRP5n+LmNvpxN+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit": "^3.1.2",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "node_modules/@lit-labs/ssr-client/node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
       "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ=="
+    },
+    "node_modules/@lit-labs/ssr/node_modules/@types/node": {
+      "version": "16.18.121",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.121.tgz",
+      "integrity": "sha512-Gk/pOy8H0cvX8qNrwzElYIECpcUn87w4EAEFXFvPJ8qsP9QR/YqukUORSy0zmyDyvdo149idPpy4W6iC5aSbQA==",
+      "license": "MIT"
+    },
+    "node_modules/@lit-labs/ssr/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@lit-labs/ssr/node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/@lit-labs/ssr/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@lit/context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.3.tgz",
+      "integrity": "sha512-Auh37F4S0PZM93HTDfZWs97mmzaQ7M3vnTc9YvxAGyP3UItSK/8Fs0vTOGT+njuvOwbKio/l8Cx/zWL4vkutpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.2 || ^2.0.0"
+      }
     },
     "node_modules/@lit/reactive-element": {
       "version": "2.0.4",
@@ -3478,6 +3662,15 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
       "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA=="
+    },
+    "node_modules/@parse5/tools": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.3.0.tgz",
+      "integrity": "sha512-zxRyTHkqb7WQMV8kTNBKWb1BeOFUKXBXTBWuxg9H9hfvQB3IwP6Iw2U75Ia5eyRxPNltmY7E8YAlz6zWwUnjKg==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -9548,8 +9741,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
@@ -10208,8 +10400,6 @@
       "version": "5.17.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
       "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -10222,7 +10412,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -10733,6 +10922,29 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fetch-retry": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.6.tgz",
@@ -10965,6 +11177,7 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.0.tgz",
       "integrity": "sha512-1td0l3pMkWJLFipobUcGaf+5DTY4PLDDrcqoSaKP8ediO/CoWCCYk/fT/Y2A4e6TNB+Sh6clRJCjOPPnKoNHnQ==",
+      "license": "MIT",
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -11018,6 +11231,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -11485,8 +11710,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphql": {
       "version": "16.9.0",
@@ -14103,6 +14327,25 @@
         "node": "*"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -14757,7 +15000,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
       "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dev": true,
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -16727,14 +16969,13 @@
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -17272,10 +17513,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.1.0",
@@ -18631,6 +18872,15 @@
       "dev": true,
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/packages/instant-apps-components/package.json
+++ b/packages/instant-apps-components/package.json
@@ -33,7 +33,7 @@
     "@arcgis/core": ">=4.32.0-next.20241010 <4.33",
     "@ckeditor/ckeditor5-build-classic": "^39.0.1",
     "@esri/arcgis-html-sanitizer": "^4.0.3",
-    "@esri/calcite-components": "3.0.0-next.45",
+    "@esri/calcite-components": "3.0.0-next.40",
     "@stencil/core": "4.17.1",
     "@stencil/react-output-target": "^0.5.3",
     "@stencil/store": "^2.0.8",

--- a/packages/instant-apps-components/package.json
+++ b/packages/instant-apps-components/package.json
@@ -33,7 +33,7 @@
     "@arcgis/core": ">=4.32.0-next.20241010 <4.33",
     "@ckeditor/ckeditor5-build-classic": "^39.0.1",
     "@esri/arcgis-html-sanitizer": "^4.0.3",
-    "@esri/calcite-components": "2.13.0",
+    "@esri/calcite-components": "3.0.0-next.45",
     "@stencil/core": "4.17.1",
     "@stencil/react-output-target": "^0.5.3",
     "@stencil/store": "^2.0.8",

--- a/packages/instant-apps-components/src/components.d.ts
+++ b/packages/instant-apps-components/src/components.d.ts
@@ -12,7 +12,6 @@ import { PredefinedOptions } from "./components/instant-apps-create/instant-apps
 import { AlignmentPositions } from "./components/instant-apps-landing-page/support/enum";
 import { AppSettings, LocaleItem, LocaleSettingData } from "./components/instant-apps-language-translator/support/interfaces";
 import { InstantAppsPopovers } from "./components/instant-apps-popovers/instant-apps-popovers";
-import { LogicalPlacement } from "@esri/calcite-components/dist/types/utils/floating-ui";
 import { ScoreboardItem, ScoreboardMode, ScoreboardPosition } from "./components/instant-apps-scoreboard/types/interfaces";
 import { ITimeInfoConfigItem } from "./components/instant-apps-time-filter/TimeFilter/interfaces/interfaces";
 export { AppGuidePage } from "./components/instant-apps-app-guide/AppGuide/interfaces/interfaces";
@@ -22,7 +21,6 @@ export { PredefinedOptions } from "./components/instant-apps-create/instant-apps
 export { AlignmentPositions } from "./components/instant-apps-landing-page/support/enum";
 export { AppSettings, LocaleItem, LocaleSettingData } from "./components/instant-apps-language-translator/support/interfaces";
 export { InstantAppsPopovers } from "./components/instant-apps-popovers/instant-apps-popovers";
-export { LogicalPlacement } from "@esri/calcite-components/dist/types/utils/floating-ui";
 export { ScoreboardItem, ScoreboardMode, ScoreboardPosition } from "./components/instant-apps-scoreboard/types/interfaces";
 export { ITimeInfoConfigItem } from "./components/instant-apps-time-filter/TimeFilter/interfaces/interfaces";
 export namespace Components {

--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/AppGuide/interfaces/interfaces.d.ts
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/AppGuide/interfaces/interfaces.d.ts
@@ -5,3 +5,5 @@ export interface AppGuidePage {
 }
 
 export type AppGuideRenderType = 'paragraphs' | 'list';
+
+export type CalciteCarouselArrowType = "inline" | "edge" | "none";

--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/instant-apps-app-guide.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/instant-apps-app-guide.tsx
@@ -1,10 +1,9 @@
 import { Component, Host, h, Prop, State } from '@stencil/core';
 import { Element, HostElement, Watch } from '@stencil/core/internal';
 import AppGuideViewModel from './AppGuide/AppGuideViewModel';
-import { AppGuidePage, AppGuideRenderType } from './AppGuide/interfaces/interfaces';
+import { AppGuidePage, AppGuideRenderType, CalciteCarouselArrowType } from './AppGuide/interfaces/interfaces';
 import AppGuide_T9n from '../../assets/t9n/instant-apps-app-guide/resources.json';
 import { getMessages } from '../../utils/locale';
-import { ArrowType } from '@esri/calcite-components';
 
 const CSS = {
   contentList: 'instant-apps-app-guide__content-list',
@@ -59,7 +58,7 @@ export class InstantAppsAppGuide {
    * Private Variables
    */
   private _viewModel: AppGuideViewModel = new AppGuideViewModel();
-  private _carouselRef: HTMLCalciteCarouselElement;
+  private _carouselRef!: HTMLCalciteCarouselElement;
 
   componentWillLoad() {
     this._setContent(this?.data);
@@ -77,8 +76,9 @@ export class InstantAppsAppGuide {
         <calcite-panel scale="s">
           { header }
           <calcite-carousel
+            label="App Guide"
             onCalciteCarouselChange={() => this._updateHeaderText()}
-            ref={ el => this._carouselRef = el }
+            ref={ el => this._carouselRef = el! }
             arrow-type={this._getArrowType()}>
             { pages }
           </calcite-carousel>
@@ -94,6 +94,8 @@ export class InstantAppsAppGuide {
 
   private _updateHeaderText() : void {
     const { _viewModel, _carouselRef, messages } = this;
+    if (!(_viewModel && _carouselRef)) return;
+
     const nodeArray = Array.from(_carouselRef.childNodes);
     const selectedNodeIndex = nodeArray.indexOf(_carouselRef.selectedItem);
 
@@ -105,7 +107,7 @@ export class InstantAppsAppGuide {
     this.headerText = selectedPage?.title || messages?.headerText;
   }
 
-  private _getArrowType() : ArrowType {
+  private _getArrowType() : CalciteCarouselArrowType {
     return this._viewModel.pages.length > 2 ? 'inline' : 'none';
   }
 
@@ -123,7 +125,7 @@ export class InstantAppsAppGuide {
     return pages.map((pageData, index) => {
       const { content, type } = pageData;
       return (
-        <calcite-carousel-item key={`page_${index}`}>
+        <calcite-carousel-item label="App Guide Panel" key={`page_${index}`}>
           <div class={CSS.contentWrapper}>
             { this._renderContentItems(content, type) }
           </div>

--- a/packages/instant-apps-components/src/components/instant-apps-app-guide/instant-apps-app-guide.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-app-guide/instant-apps-app-guide.tsx
@@ -123,9 +123,9 @@ export class InstantAppsAppGuide {
 
   private _renderAppGuidePages(pages: AppGuidePage[]) : HTMLCalciteCarouselItemElement[] {
     return pages.map((pageData, index) => {
-      const { content, type } = pageData;
+      const { content, type, title } = pageData;
       return (
-        <calcite-carousel-item label="App Guide Panel" key={`page_${index}`}>
+        <calcite-carousel-item label={title} key={`page_${index}`}>
           <div class={CSS.contentWrapper}>
             { this._renderContentItems(content, type) }
           </div>

--- a/packages/instant-apps-components/src/instant-apps-app-guide.html
+++ b/packages/instant-apps-components/src/instant-apps-app-guide.html
@@ -16,7 +16,7 @@
     <script type="module" src="https://cdn.jsdelivr.net/npm/@esri/calcite-components@3.0.0-next.40/dist/calcite/calcite.esm.js"></script>
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@esri/calcite-components@3.0.0-next.40/dist/calcite/calcite.css" />
     <script src="https://jsdev.arcgis.com/4.32/"></script>
-    <script type="module" src="https://js.arcgis.com/map-components/4.30/arcgis-map-components.esm.js"></script>
+    <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
     <script type="module" src="/build/instant-apps-components.esm.js"></script>
     <script nomodule src="/build/instant-apps-components.js"></script>
 


### PR DESCRIPTION
## Summary
Update the App Guide component so that it functions properly when it has a dependency on Calcite 3.

## Details
- Fixed a11y, required property, and type errors
- Updated the version of map components used by the demo page

## Testing
- Inspected the demo page to ensure
  - there are no errors related to the App Guide in the server and browser consoles
  - the App Guide opens and closes, and displays as expected with 1, 2, and 3+ pages