### PR TITLE
chore: Update  deprecated prop in filter

### DIFF
--- a/packages/instant-apps-components/src/components/instant-apps-filter-list/instant-apps-filter-list.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-filter-list/instant-apps-filter-list.tsx
@@ -346,7 +346,7 @@ export class InstantAppsFilterList {
     const selectedFields = expression?.selectedFields as unknown[];
     const selected = selectedFields?.includes(value) ?? false;
 
-    return <calcite-combobox-item key={`${label}-${index}`} value={value} textLabel={`${label}`} selected={selected}></calcite-combobox-item>;
+    return <calcite-combobox-item key={`${label}-${index}`} value={value} heading={`${label}`} selected={selected}></calcite-combobox-item>;
   }
 
   initFilterConfig(): VNode[] | undefined {


### PR DESCRIPTION
I checked  the following components and the tests looks good and I didn't see any breaking changes so I think if all of @rslibed  and @JoeRodriguez-136  updates are in then we should be done with calcite 3 updates in this repo. 

Create, Export Views, Export, FilterList, SIgnin

