### PR TITLE
Add Print Orientation and Size to Export

### DIFF
--- a/packages/instant-apps-components/src/assets/t9n/instant-apps-export/resources.json
+++ b/packages/instant-apps-components/src/assets/t9n/instant-apps-export/resources.json
@@ -39,6 +39,8 @@
     "a1": "A1",
     "a3": "A3",
     "a4": "A4",
-    "tabloid": "Tabloid"
+    "tabloid": "Tabloid",
+    "letteransia": "Letter ANSI A",
+    "tabloidansib": "Tabloid ANSI B"
   }
 }

--- a/packages/instant-apps-components/src/assets/t9n/instant-apps-export/resources.json
+++ b/packages/instant-apps-components/src/assets/t9n/instant-apps-export/resources.json
@@ -28,5 +28,17 @@
   "screenshotLayout": "Screenshot layout",
   "horizontal": "Horizontal",
   "preview": "Preview",
-  "vertical": "Vertical"
+  "vertical": "Vertical",
+  "selectPrintOrientation": "Select page orientation",
+  "selectPrintSize": "Select print size",
+  "portrait": "Portrait",
+  "landscape": "Landscape",
+  "printSize": {
+    "letter": "Letter",
+    "legal": "Legal",
+    "a1": "A1",
+    "a3": "A3",
+    "a4": "A4",
+    "tabloid": "Tabloid"
+  }
 }

--- a/packages/instant-apps-components/src/assets/t9n/instant-apps-export/resources_en.json
+++ b/packages/instant-apps-components/src/assets/t9n/instant-apps-export/resources_en.json
@@ -39,6 +39,8 @@
     "a1": "A1",
     "a3": "A3",
     "a4": "A4",
-    "tabloid": "Tabloid"
+    "tabloid": "Tabloid",
+    "letteransia": "Letter ANSI A",
+    "tabloidansib": "Tabloid ANSI B"
   }
 }

--- a/packages/instant-apps-components/src/assets/t9n/instant-apps-export/resources_en.json
+++ b/packages/instant-apps-components/src/assets/t9n/instant-apps-export/resources_en.json
@@ -28,5 +28,17 @@
   "screenshotLayout": "Screenshot layout",
   "horizontal": "Horizontal",
   "preview": "Preview",
-  "vertical": "Vertical"
+  "vertical": "Vertical",
+  "selectPrintOrientation": "Select page orientation",
+  "selectPrintSize": "Select print size",
+  "portrait": "Portrait",
+  "landscape": "Landscape",
+  "printSize": {
+    "letter": "Letter",
+    "legal": "Legal",
+    "a1": "A1",
+    "a3": "A3",
+    "a4": "A4",
+    "tabloid": "Tabloid"
+  }
 }

--- a/packages/instant-apps-components/src/components/instant-apps-export/instant-apps-export.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-export/instant-apps-export.tsx
@@ -36,6 +36,7 @@ const CSS = {
 };
 
 const dragHandlerName = 'instant-app-export-drag';
+type PrintSize = 'Letter' | 'Legal' | 'A1' | 'A3' | 'A4' | 'Tabloid';
 
 @Component({
   tag: 'instant-apps-export',
@@ -133,7 +134,7 @@ export class InstantAppsExport {
   /**
    * Determines the size of the export.
    */
-  @Prop() printSize?: 'Letter' | 'Legal' | 'A1' | 'A3' | 'A4' | 'Tabloid' = 'Letter';
+  @Prop() printSize?: PrintSize = 'Letter';
 
   /**
    * Adjusts the scale of the action button.
@@ -299,6 +300,7 @@ export class InstantAppsExport {
     const options = this.includeMap ? this.renderMapOptions() : null;
     const fileType = this.includeFileFormat ? this.renderSelectFileType() : null;
     const printOrientation = this.selectedFileType === 'PDF' ? this.renderSelectPrintOrientation() : null;
+    const printSize = this.selectedFileType === 'PDF' ? this.renderSelectPrintSize() : null;
     const print = this.selectedFileType === 'PDF' ? this.renderPrint() : this.renderImg();
     const panelClass = this.mode === 'inline' ? CSS.inlineContainer : CSS.popoverContainer;
     return (
@@ -309,6 +311,7 @@ export class InstantAppsExport {
         {options}
         {fileType}
         {printOrientation}
+        {printSize}
         {this.includeMap ? (
           <calcite-button appearance="transparent" width="full" onClick={this.setMapAreaOnClick.bind(this, true)} disabled={this.exportIsLoading}>
             {this.messages?.setMapArea}
@@ -368,6 +371,22 @@ export class InstantAppsExport {
           <calcite-option value={'Landscape'} selected={this.printOrientation === 'Landscape'}>
             {this.messages?.landscape}
           </calcite-option>
+        </calcite-select>
+      </calcite-label>
+    );
+  }
+
+  renderSelectPrintSize(): VNode {
+    const printSizes: PrintSize[] = ['Letter', 'Legal', 'A1', 'A3', 'A4', 'Tabloid'];
+    return (
+      <calcite-label>
+        {this.messages?.selectPrintSize}
+        <calcite-select label="" onCalciteSelectChange={this.handleSelectPrintSize.bind(this)}>
+          {printSizes.map((size) => (
+            <calcite-option value={size} selected={size === this.printSize}>
+              {this.messages?.printSize[size.toLowerCase()]}
+            </calcite-option>
+          ))}
         </calcite-select>
       </calcite-label>
     );
@@ -1051,6 +1070,11 @@ export class InstantAppsExport {
   handleSelectPrintOrientation(e: CustomEvent): void {
     const node = e.target as HTMLCalciteSelectElement;
     this.printOrientation = node.value as 'Portrait' | 'Landscape';
+  }
+
+  handleSelectPrintSize(e: CustomEvent): void {
+    const node = e.target as HTMLCalciteSelectElement;
+    this.printSize = node.value as PrintSize;
   }
 
   /*

--- a/packages/instant-apps-components/src/components/instant-apps-export/instant-apps-export.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-export/instant-apps-export.tsx
@@ -116,11 +116,6 @@ export class InstantAppsExport {
   @Prop({ reflect: true }) mode: 'popover' | 'inline' = 'popover';
 
   /**
-   * Determines the size of the export.
-   */
-  @Prop() pageSize?: 'portrait' | 'landscape' | 'A1' = 'portrait';
-
-  /**
    * Determines the type of positioning to use for the overlaid content. Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout. `"fixed"` value should be used to escape an overflowing parent container, or when the reference element's position CSS property is `"fixed"`.
    */
   @Prop() popoverPositioning?: 'absolute' | 'fixed' = 'absolute';
@@ -129,6 +124,16 @@ export class InstantAppsExport {
    * Determines where the component will be positioned relative to the `referenceElement`.
    */
   @Prop() popoverPlacement?: PopoverPlacement = 'auto';
+
+  /**
+   * Determines the print page orientation of the export.
+   */
+  @Prop() printOrientation?: 'Portrait' | 'Landscape' = 'Portrait';
+
+  /**
+   * Determines the size of the export.
+   */
+  @Prop() printSize?: 'Letter' | 'Legal' | 'A1' | 'A3' | 'A4' | 'Tabloid' = 'Letter';
 
   /**
    * Adjusts the scale of the action button.
@@ -293,6 +298,7 @@ export class InstantAppsExport {
     const includeMap = this.showIncludeMap ? this.renderSwitch('includeMap', undefined, this.selectedFileType !== 'PDF') : null;
     const options = this.includeMap ? this.renderMapOptions() : null;
     const fileType = this.includeFileFormat ? this.renderSelectFileType() : null;
+    const printOrientation = this.selectedFileType === 'PDF' ? this.renderSelectPrintOrientation() : null;
     const print = this.selectedFileType === 'PDF' ? this.renderPrint() : this.renderImg();
     const panelClass = this.mode === 'inline' ? CSS.inlineContainer : CSS.popoverContainer;
     return (
@@ -302,6 +308,7 @@ export class InstantAppsExport {
         {includeMap}
         {options}
         {fileType}
+        {printOrientation}
         {this.includeMap ? (
           <calcite-button appearance="transparent" width="full" onClick={this.setMapAreaOnClick.bind(this, true)} disabled={this.exportIsLoading}>
             {this.messages?.setMapArea}
@@ -345,6 +352,22 @@ export class InstantAppsExport {
               {fileType}
             </calcite-option>
           ))}
+        </calcite-select>
+      </calcite-label>
+    );
+  }
+
+  renderSelectPrintOrientation(): VNode {
+    return (
+      <calcite-label>
+        {this.messages?.selectPrintOrientation}
+        <calcite-select label="" onCalciteSelectChange={this.handleSelectPrintOrientation.bind(this)}>
+          <calcite-option value={'Portrait'} selected={this.printOrientation === 'Portrait'}>
+            {this.messages?.portrait}
+          </calcite-option>
+          <calcite-option value={'Landscape'} selected={this.printOrientation === 'Landscape'}>
+            {this.messages?.landscape}
+          </calcite-option>
         </calcite-select>
       </calcite-label>
     );
@@ -514,8 +537,8 @@ export class InstantAppsExport {
   addPrintStyling(): void {
     if (this.printStyleEl == null) {
       this.printStyleEl = document.createElement('style');
-      if (this.pageSize !== 'portrait') {
-        const updatedPrintStyling = printStyling.replace(/size:\s*\w+;/, `size: ${this.pageSize};`);
+      if (this.printOrientation !== 'Portrait' || this.printSize !== 'Letter') {
+        const updatedPrintStyling = printStyling.replace(/size:\s*\w+;/, `size: ${this.printSize} ${this.printOrientation};`);
         this.printStyleEl.innerHTML = updatedPrintStyling;
       } else {
         this.printStyleEl.innerHTML = printStyling;
@@ -784,7 +807,7 @@ export class InstantAppsExport {
   setMaxRowHeightOnViewContainer(): void {
     if (this.selectedFileType === 'PDF') {
       this.printEl.style.gridTemplateRows = 'minmax(auto, 70%)';
-      this.printEl.style.zIndex = this.getMaxZIndex().toString();
+      //this.printEl.style.zIndex = this.getMaxZIndex().toString();
     }
     this.viewEl.style.height = '100%';
     this.viewEl.style.width = '';
@@ -794,7 +817,7 @@ export class InstantAppsExport {
 
   setMaxWidthOnViewContainer(): void {
     this.printEl.style.gridTemplateRows = '';
-    this.printEl.style.zIndex = this.getMaxZIndex().toString();
+    //this.printEl.style.zIndex = this.getMaxZIndex().toString();
     this.viewEl.style.width = '100%';
     this.viewEl.style.height = '';
     this.viewWrapperEl.style.height = 'fit-content';
@@ -1025,6 +1048,12 @@ export class InstantAppsExport {
     }
   }
 
+  handleSelectPrintOrientation(e: CustomEvent): void {
+    const node = e.target as HTMLCalciteSelectElement;
+    this.printOrientation = node.value as 'Portrait' | 'Landscape';
+  }
+
+  /*
   getMaxZIndex() {
     let elements = document.getElementsByTagName("*");
     let maxZIndex = 0;
@@ -1036,4 +1065,5 @@ export class InstantAppsExport {
     }
     return maxZIndex;
   }
+    */
 }

--- a/packages/instant-apps-components/src/components/instant-apps-export/instant-apps-export.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-export/instant-apps-export.tsx
@@ -36,7 +36,7 @@ const CSS = {
 };
 
 const dragHandlerName = 'instant-app-export-drag';
-type PrintSize = 'Letter' | 'Legal' | 'A1' | 'A3' | 'A4' | 'Tabloid';
+type PrintSize = 'Letter' | 'Legal' | 'A1' | 'A3' | 'A4' | 'Tabloid' | 'Letter ANSI A' | 'Tabloid ANSI B';
 
 @Component({
   tag: 'instant-apps-export',
@@ -377,14 +377,14 @@ export class InstantAppsExport {
   }
 
   renderSelectPrintSize(): VNode {
-    const printSizes: PrintSize[] = ['Letter', 'Legal', 'A1', 'A3', 'A4', 'Tabloid'];
+    const printSizes: PrintSize[] = ['Letter', 'Legal', 'A1', 'A3', 'A4', 'Tabloid', 'Letter ANSI A', 'Tabloid ANSI B'];
     return (
       <calcite-label>
         {this.messages?.selectPrintSize}
         <calcite-select label="" onCalciteSelectChange={this.handleSelectPrintSize.bind(this)}>
           {printSizes.map((size) => (
             <calcite-option value={size} selected={size === this.printSize}>
-              {this.messages?.printSize[size.toLowerCase()]}
+              {this.messages?.printSize[size.replace(/\s/g, '').toLowerCase()]}
             </calcite-option>
           ))}
         </calcite-select>

--- a/packages/instant-apps-components/src/components/instant-apps-export/instant-apps-export.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-export/instant-apps-export.tsx
@@ -116,6 +116,11 @@ export class InstantAppsExport {
   @Prop({ reflect: true }) mode: 'popover' | 'inline' = 'popover';
 
   /**
+   * Determines the size of the export.
+   */
+  @Prop() pageSize?: 'portrait' | 'landscape' | 'A1' = 'portrait';
+
+  /**
    * Determines the type of positioning to use for the overlaid content. Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout. `"fixed"` value should be used to escape an overflowing parent container, or when the reference element's position CSS property is `"fixed"`.
    */
   @Prop() popoverPositioning?: 'absolute' | 'fixed' = 'absolute';
@@ -509,7 +514,12 @@ export class InstantAppsExport {
   addPrintStyling(): void {
     if (this.printStyleEl == null) {
       this.printStyleEl = document.createElement('style');
-      this.printStyleEl.innerHTML = printStyling;
+      if (this.pageSize !== 'portrait') {
+        const updatedPrintStyling = printStyling.replace(/size:\s*\w+;/, `size: ${this.pageSize};`);
+        this.printStyleEl.innerHTML = updatedPrintStyling;
+      } else {
+        this.printStyleEl.innerHTML = printStyling;
+      }
       document.body.prepend(this.printStyleEl);
     }
   }
@@ -774,6 +784,7 @@ export class InstantAppsExport {
   setMaxRowHeightOnViewContainer(): void {
     if (this.selectedFileType === 'PDF') {
       this.printEl.style.gridTemplateRows = 'minmax(auto, 70%)';
+      this.printEl.style.zIndex = this.getMaxZIndex().toString();
     }
     this.viewEl.style.height = '100%';
     this.viewEl.style.width = '';
@@ -783,6 +794,7 @@ export class InstantAppsExport {
 
   setMaxWidthOnViewContainer(): void {
     this.printEl.style.gridTemplateRows = '';
+    this.printEl.style.zIndex = this.getMaxZIndex().toString();
     this.viewEl.style.width = '100%';
     this.viewEl.style.height = '';
     this.viewWrapperEl.style.height = 'fit-content';
@@ -1011,5 +1023,17 @@ export class InstantAppsExport {
         this.includeExtraContent = false;
       }
     }
+  }
+
+  getMaxZIndex() {
+    let elements = document.getElementsByTagName("*");
+    let maxZIndex = 0;
+    for (let element of elements) {
+      let zIndex = window.getComputedStyle(element).zIndex;
+      if (!isNaN(parseInt(zIndex))) {
+        maxZIndex = Math.max(maxZIndex, parseInt(zIndex, 10));
+      }
+    }
+    return maxZIndex;
   }
 }

--- a/packages/instant-apps-components/src/components/instant-apps-export/instant-apps-export.tsx
+++ b/packages/instant-apps-components/src/components/instant-apps-export/instant-apps-export.tsx
@@ -826,7 +826,6 @@ export class InstantAppsExport {
   setMaxRowHeightOnViewContainer(): void {
     if (this.selectedFileType === 'PDF') {
       this.printEl.style.gridTemplateRows = 'minmax(auto, 70%)';
-      //this.printEl.style.zIndex = this.getMaxZIndex().toString();
     }
     this.viewEl.style.height = '100%';
     this.viewEl.style.width = '';
@@ -836,7 +835,6 @@ export class InstantAppsExport {
 
   setMaxWidthOnViewContainer(): void {
     this.printEl.style.gridTemplateRows = '';
-    //this.printEl.style.zIndex = this.getMaxZIndex().toString();
     this.viewEl.style.width = '100%';
     this.viewEl.style.height = '';
     this.viewWrapperEl.style.height = 'fit-content';
@@ -1077,17 +1075,4 @@ export class InstantAppsExport {
     this.printSize = node.value as PrintSize;
   }
 
-  /*
-  getMaxZIndex() {
-    let elements = document.getElementsByTagName("*");
-    let maxZIndex = 0;
-    for (let element of elements) {
-      let zIndex = window.getComputedStyle(element).zIndex;
-      if (!isNaN(parseInt(zIndex))) {
-        maxZIndex = Math.max(maxZIndex, parseInt(zIndex, 10));
-      }
-    }
-    return maxZIndex;
-  }
-    */
 }


### PR DESCRIPTION
Solutions has a desire to use ```instant-app-export``` component in Experience Builder to handle client side printing without the need to have server side print server.

But, would like this component to have page size and orientation options added.  This PR adds two drops to handle these based on PDF selected as the file type.

Please assign reviewer/assignee accordingly.